### PR TITLE
91 backend alert deactivation

### DIFF
--- a/apps/backend/src/app/alerting/alerting.controller.ts
+++ b/apps/backend/src/app/alerting/alerting.controller.ts
@@ -1,4 +1,13 @@
-import { Body, Controller, Get, Logger, Post, Query } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Logger,
+  Param,
+  Post,
+  Put,
+  Query,
+} from '@nestjs/common';
 import {
   ApiBody,
   ApiConflictResponse,
@@ -24,6 +33,34 @@ export class AlertingController {
   @ApiBody({ type: CreateAlertTypeDto })
   async createAlertType(@Body() createAlertTypeDto: CreateAlertTypeDto) {
     await this.alertingService.createAlertType(createAlertTypeDto);
+  }
+
+  @Put('type/:alertTypeId/activate/user')
+  @ApiOperation({ summary: 'Activate Alert Type by user.' })
+  @ApiNotFoundResponse({ description: 'Alert type not found' })
+  async userActivateAlertType(@Param('alertTypeId') alertTypeId: string) {
+    await this.alertingService.userActivateAlertType(alertTypeId);
+  }
+
+  @Put('type/:alertTypeId/deactivate/user')
+  @ApiOperation({ summary: 'Deactivate Alert Type by user' })
+  @ApiNotFoundResponse({ description: 'Alert type not found' })
+  async userDeactivateAlertType(@Param('alertTypeId') alertTypeId: string) {
+    await this.alertingService.userDeactivateAlertType(alertTypeId);
+  }
+
+  @Put('type/:alertTypeId/activate/admin')
+  @ApiOperation({ summary: 'Activate Alert Type by admin.' })
+  @ApiNotFoundResponse({ description: 'Alert type not found' })
+  async adminActivateAlertType(@Param('alertTypeId') alertTypeId: string) {
+    await this.alertingService.adminActivateAlertType(alertTypeId);
+  }
+
+  @Put('type/:alertTypeId/deactivate/admin')
+  @ApiOperation({ summary: 'Deactivate Alert Type by admin' })
+  @ApiNotFoundResponse({ description: 'Alert type not found' })
+  async adminDeactivateAlertType(@Param('alertTypeId') alertTypeId: string) {
+    await this.alertingService.adminDeactivateAlertType(alertTypeId);
   }
 
   @Get('type')

--- a/apps/backend/src/app/alerting/alerting.controller.ts
+++ b/apps/backend/src/app/alerting/alerting.controller.ts
@@ -4,8 +4,8 @@ import {
   Get,
   Logger,
   Param,
+  Patch,
   Post,
-  Put,
   Query,
 } from '@nestjs/common';
 import {
@@ -35,28 +35,28 @@ export class AlertingController {
     await this.alertingService.createAlertType(createAlertTypeDto);
   }
 
-  @Put('type/:alertTypeId/activate/user')
+  @Patch('type/:alertTypeId/activate/user')
   @ApiOperation({ summary: 'Activate Alert Type by user.' })
   @ApiNotFoundResponse({ description: 'Alert type not found' })
   async userActivateAlertType(@Param('alertTypeId') alertTypeId: string) {
     await this.alertingService.userActivateAlertType(alertTypeId);
   }
 
-  @Put('type/:alertTypeId/deactivate/user')
+  @Patch('type/:alertTypeId/deactivate/user')
   @ApiOperation({ summary: 'Deactivate Alert Type by user' })
   @ApiNotFoundResponse({ description: 'Alert type not found' })
   async userDeactivateAlertType(@Param('alertTypeId') alertTypeId: string) {
     await this.alertingService.userDeactivateAlertType(alertTypeId);
   }
 
-  @Put('type/:alertTypeId/activate/admin')
+  @Patch('type/:alertTypeId/activate/admin')
   @ApiOperation({ summary: 'Activate Alert Type by admin.' })
   @ApiNotFoundResponse({ description: 'Alert type not found' })
   async adminActivateAlertType(@Param('alertTypeId') alertTypeId: string) {
     await this.alertingService.adminActivateAlertType(alertTypeId);
   }
 
-  @Put('type/:alertTypeId/deactivate/admin')
+  @Patch('type/:alertTypeId/deactivate/admin')
   @ApiOperation({ summary: 'Deactivate Alert Type by admin' })
   @ApiNotFoundResponse({ description: 'Alert type not found' })
   async adminDeactivateAlertType(@Param('alertTypeId') alertTypeId: string) {
@@ -108,7 +108,7 @@ export class AlertingController {
   @ApiOperation({ summary: 'Create a new size alert.' })
   @ApiNotFoundResponse({ description: 'Backup not found' })
   @ApiBody({ type: CreateSizeAlertDto })
-  async createSIzeAlert(
+  async createSizeAlert(
     @Body() createSizeAlertDto: CreateSizeAlertDto
   ): Promise<void> {
     await this.alertingService.createSizeAlert(createSizeAlertDto);

--- a/apps/backend/src/app/alerting/alerting.service.ts
+++ b/apps/backend/src/app/alerting/alerting.service.ts
@@ -41,6 +41,30 @@ export class AlertingService {
     return await this.alertTypeRepository.save(createAlertTypeDto);
   }
 
+  async userActivateAlertType(alertTypeId: string) {
+    const alertType = await this.findAlertTypeByIdOrThrow(alertTypeId);
+    alertType.user_active = true;
+    return await this.alertTypeRepository.save(alertType);
+  }
+
+  async userDeactivateAlertType(alertTypeId: string) {
+    const alertType = await this.findAlertTypeByIdOrThrow(alertTypeId);
+    alertType.user_active = false;
+    return await this.alertTypeRepository.save(alertType);
+  }
+
+  async adminActivateAlertType(alertTypeId: string) {
+    const alertType = await this.findAlertTypeByIdOrThrow(alertTypeId);
+    alertType.master_active = true;
+    return await this.alertTypeRepository.save(alertType);
+  }
+
+  async adminDeactivateAlertType(alertTypeId: string) {
+    const alertType = await this.findAlertTypeByIdOrThrow(alertTypeId);
+    alertType.master_active = false;
+    return await this.alertTypeRepository.save(alertType);
+  }
+
   async findAllAlertTypes(
     user_active?: boolean,
     master_active?: boolean
@@ -116,5 +140,13 @@ export class AlertingService {
     if (alert.alertType.user_active && alert.alertType.master_active) {
       await this.triggerAlertMail(alert);
     }
+  }
+
+  private async findAlertTypeByIdOrThrow(id: string): Promise<AlertTypeEntity> {
+    const entity = await this.alertTypeRepository.findOneBy({ id });
+    if (!entity) {
+      throw new NotFoundException(`Alert type with id ${id} not found`);
+    }
+    return entity;
   }
 }

--- a/apps/backend/src/app/alerting/alerting.service.ts
+++ b/apps/backend/src/app/alerting/alerting.service.ts
@@ -84,7 +84,7 @@ export class AlertingService {
   }
 
   async getAllAlerts(backupId?: string, days?: number): Promise<Alert[]> {
-    const where: FindOptionsWhere<Alert> = {};
+    const where: FindOptionsWhere<Alert> = { alertType: { user_active: true, master_active: true } };
     if (backupId) {
       where.backup = { id: backupId };
     }


### PR DESCRIPTION
Criterion 1: The Backend module offers an api to store the status on or off for every alert.
Criterion 2: The Backend module only forwards alerts to the frontend when the respective alert is activated.
Criterion 3: The Backend module only forwards alerts by email when the respective alert is activated.