### PR TITLE
82 analysis module rule based alert   backup creation time alert

### DIFF
--- a/apps/analyzer/metadata_analyzer/analyzer.py
+++ b/apps/analyzer/metadata_analyzer/analyzer.py
@@ -93,13 +93,6 @@ class Analyzer:
 
     def simple_rule_based_analysis_creation_dates(alert_limit):
         data = list(Analyzer.database.get_results())
-        latest_creation_alert_id = Analyzer.backend.get_latest_creation_date_alert()
-        if latest_creation_alert_id == "":
-            start_date = datetime.datetime.min
-        else:
-            latest_creation_alerts = [result.start_time for result in data if result.uuid == latest_creation_alert_id]
-            assert len(latest_creation_alerts) == 1
-            start_date = latest_creation_alerts[0]
-
+        start_date = Analyzer._get_start_date(data, "CREATION_DATE_ALERT", None)
         result = Analyzer.simple_rule_based_analyzer.analyze_creation_dates(data, alert_limit, start_date)
         return result

--- a/apps/analyzer/metadata_analyzer/analyzer.py
+++ b/apps/analyzer/metadata_analyzer/analyzer.py
@@ -68,3 +68,8 @@ class Analyzer:
         data = list(Analyzer.database.get_results())
         result = Analyzer.simple_rule_based_analyzer.analyze_inc(data,alert_limit)
         return result
+
+    def simple_rule_based_analysis_creation_dates(alert_limit):
+        data = list(Analyzer.database.get_results())
+        result = Analyzer.simple_rule_based_analyzer.analyze_creation_dates(data, alert_limit)
+        return result

--- a/apps/analyzer/metadata_analyzer/analyzer.py
+++ b/apps/analyzer/metadata_analyzer/analyzer.py
@@ -1,3 +1,5 @@
+import datetime
+
 class Analyzer:
     def init(database, backend, simple_analyzer, simple_rule_based_analyzer):
         Analyzer.database = database
@@ -71,5 +73,13 @@ class Analyzer:
 
     def simple_rule_based_analysis_creation_dates(alert_limit):
         data = list(Analyzer.database.get_results())
-        result = Analyzer.simple_rule_based_analyzer.analyze_creation_dates(data, alert_limit)
+        latest_creation_alert_id = Analyzer.backend.get_latest_creation_date_alert()
+        if latest_creation_alert_id == "":
+            start_date = datetime.datetime.min
+        else:
+            latest_creation_alerts = [result.start_time for result in data if result.uuid == latest_creation_alert_id]
+            assert len(latest_creation_alerts) == 1
+            start_date = latest_creation_alerts[0]
+
+        result = Analyzer.simple_rule_based_analyzer.analyze_creation_dates(data, alert_limit, start_date)
         return result

--- a/apps/analyzer/metadata_analyzer/backend.py
+++ b/apps/analyzer/metadata_analyzer/backend.py
@@ -13,3 +13,7 @@ class Backend:
         url = self.backend_url + "alerting/size"
         r = requests.post(url, json=alert)
         r.raise_for_status()
+
+    def create_creation_date_alert(self, alert):
+        url = self.backend_url + "alerting/creationDate"
+        r = requests.post(url, json=alert)

--- a/apps/analyzer/metadata_analyzer/backend.py
+++ b/apps/analyzer/metadata_analyzer/backend.py
@@ -18,3 +18,9 @@ class Backend:
         url = self.backend_url + "alerting/creationDate"
         r = requests.post(url, json=alert)
         r.raise_for_status()
+
+    def get_latest_creation_date_alert(self):
+        url = self.backend_url + "alerting/type/creationDate/latest"
+        r = requests.get(url)
+        r.raise_for_status()
+        return r.text

--- a/apps/analyzer/metadata_analyzer/backend.py
+++ b/apps/analyzer/metadata_analyzer/backend.py
@@ -17,3 +17,4 @@ class Backend:
     def create_creation_date_alert(self, alert):
         url = self.backend_url + "alerting/creationDate"
         r = requests.post(url, json=alert)
+        r.raise_for_status()

--- a/apps/analyzer/metadata_analyzer/main.py
+++ b/apps/analyzer/metadata_analyzer/main.py
@@ -161,6 +161,16 @@ def simple_rule_based_analysis_inc():
     alert_limit = json["alertLimit"]
     return jsonify(Analyzer.simple_rule_based_analysis_inc(alert_limit))
 
+@app.route("/simpleRuleBasedAnalysisCreationDates", methods=["POST"])
+def simple_rule_based_analysis_creation_dates():
+    alert_limit = request.args.get("alertLimit")
+
+    try:
+        int(alert_limit)
+        return jsonify(Analyzer.simple_rule_based_analysis_creation_dates(int(alert_limit)))
+    except ValueError:
+        return "Invalid value for alert limit", 400
+
 def main():
     database = Database()
     backend = Backend(os.getenv("BACKEND_URL"))

--- a/apps/analyzer/metadata_analyzer/main.py
+++ b/apps/analyzer/metadata_analyzer/main.py
@@ -163,6 +163,20 @@ def simple_rule_based_analysis_inc():
 
 @app.route("/simpleRuleBasedAnalysisCreationDates", methods=["POST"])
 def simple_rule_based_analysis_creation_dates():
+    """Runs a simple rule based analysis on full backups searching for unusual creation times
+    ---
+    parameters:
+      - name: Input
+        in: query
+        name: alertLimit
+        schema:
+            type: integer
+    responses:
+        200:
+            description: Number of created alerts
+        400:
+            description: The value set for the alert limit was not valid
+    """
     alert_limit = request.args.get("alertLimit")
 
     try:

--- a/apps/analyzer/metadata_analyzer/simple_rule_based_analyzer.py
+++ b/apps/analyzer/metadata_analyzer/simple_rule_based_analyzer.py
@@ -234,8 +234,8 @@ class SimpleRuleBasedAnalyzer:
             reference_date = datetime.combine(result.start_time, reference_time)
             if smallest_diff > 60 * 60:
                 alerts.append({
-                    "date": result.start_time,
-                    "referenceDate": reference_date,
+                    "date": result.start_time.isoformat(),
+                    "referenceDate": reference_date.isoformat(),
                     "backupId": result.uuid
                 })
 

--- a/apps/analyzer/metadata_analyzer/simple_rule_based_analyzer.py
+++ b/apps/analyzer/metadata_analyzer/simple_rule_based_analyzer.py
@@ -196,7 +196,7 @@ class SimpleRuleBasedAnalyzer:
         count = len(alerts) if alert_limit == -1 else min(alert_limit, len(alerts))
         # Send the alerts to the backend
         for alert in alerts[:count]:
-            self.backend.create_alert(alert)
+            self.backend.create_creation_date_alert(alert)
 
         return {
             "count": count

--- a/apps/analyzer/metadata_analyzer/simple_rule_based_analyzer.py
+++ b/apps/analyzer/metadata_analyzer/simple_rule_based_analyzer.py
@@ -177,12 +177,12 @@ class SimpleRuleBasedAnalyzer:
         }
     
 
-    # Analyzes the creation times of a group of results from one task
+    # Analyzes the creation times of a group of results from one task.
     def _analyze_creation_times(self, results):
         SECONDS_PER_DAY = 24 * 60 * 60
 
         alerts = []
-        print("NEW")
+        print(f"NEW {len(results)}")
         times = [results[0].start_time]
         # Skip the first result
         for result in results[1:]:
@@ -199,6 +199,12 @@ class SimpleRuleBasedAnalyzer:
                     smallest_diff = diff
                     reference_time = ref_time.time()
 
+                # Early abort if the diff is already small enough
+                if diff < 60 * 60:
+                    break
+
+            # Reference date consists of the time of the nearest backup in the past and
+            # the date of the actual backup
             reference_date = datetime.combine(result.start_time, reference_time)
             if smallest_diff > 60 * 60:
                 alerts.append({
@@ -207,8 +213,8 @@ class SimpleRuleBasedAnalyzer:
                     "backupId": result.uuid
                 })
 
+            # Put the current backup time into the reference times
             times.append(time)
-        print(alerts)
         return alerts
 
 

--- a/apps/analyzer/tests/mock_backend.py
+++ b/apps/analyzer/tests/mock_backend.py
@@ -2,9 +2,13 @@ class MockBackend:
     def __init__(self):
         self.backups = []
         self.alerts = []
+        self.creation_date_alerts = []
 
     def send_backup_data_batched(self, batch):
         self.backups += batch
 
     def create_alert(self, alert):
         self.alerts.append(alert)
+
+    def create_creation_date_alert(self, alert):
+        self.creation_date_alerts.append(alert)

--- a/apps/analyzer/tests/mock_backend.py
+++ b/apps/analyzer/tests/mock_backend.py
@@ -3,6 +3,7 @@ class MockBackend:
         self.backups = []
         self.alerts = []
         self.creation_date_alerts = []
+        self.latest_creation_alert = ""
 
     def send_backup_data_batched(self, batch):
         self.backups += batch
@@ -12,3 +13,9 @@ class MockBackend:
 
     def create_creation_date_alert(self, alert):
         self.creation_date_alerts.append(alert)
+
+    def set_latest_creation_date_alert(self, latest_creation_alert):
+        self.latest_creation_alert = latest_creation_alert
+
+    def get_latest_creation_date_alert(self):
+        return self.latest_creation_alert

--- a/apps/analyzer/tests/test_simple_rule_based_analyzer.py
+++ b/apps/analyzer/tests/test_simple_rule_based_analyzer.py
@@ -325,3 +325,141 @@ def test_alert_backup_size_irregularSize_inc():
         "referenceSize": avg / 1_000_000,
         "backupId": mock_result3.uuid
     }]
+
+# Tests for the creation time alerts
+
+# Same exact time each day
+def test_alert_exact_time():
+    mock_result1 = _create_mock_result("foo", "1", "F", 100_000_000, datetime.fromisoformat("2000-01-01T03:00:00"))
+    mock_result2 = _create_mock_result("foo", "2", "F", 100_000_000, datetime.fromisoformat("2000-01-02T03:00:00"))
+    mock_result3 = _create_mock_result("foo", "3", "F", 100_000_000, datetime.fromisoformat("2000-01-03T03:00:00"))
+    mock_result4 = _create_mock_result("foo", "4", "F", 100_000_000, datetime.fromisoformat("2000-01-04T03:00:00"))
+
+    database = MockDatabase([mock_result1, mock_result2, mock_result3, mock_result4])
+    backend = MockBackend()
+    simple_rule_based_analyzer = SimpleRuleBasedAnalyzer(backend, 0.2, 0.2, 0.2, 0.2)
+    Analyzer.init(database, backend, None, simple_rule_based_analyzer)
+    Analyzer.simple_rule_based_analysis(1)
+
+    assert backend.alerts == []
+
+# Deviations up to 15 mins from the first backup
+def test_alert_small_time_deviation():
+    mock_result1 = _create_mock_result("foo", "1", "F", 100_000_000, datetime.fromisoformat("2000-01-01T12:00:00"))
+    mock_result2 = _create_mock_result("foo", "2", "F", 100_000_000, datetime.fromisoformat("2000-02-01T12:05:00"))
+    mock_result3 = _create_mock_result("foo", "3", "F", 100_000_000, datetime.fromisoformat("2000-03-01T12:15:00"))
+    mock_result4 = _create_mock_result("foo", "4", "F", 100_000_000, datetime.fromisoformat("2000-04-01T11:55:00"))
+    mock_result5 = _create_mock_result("foo", "5", "F", 100_000_000, datetime.fromisoformat("2000-05-01T11:45:00"))
+
+    database = MockDatabase([mock_result1, mock_result2, mock_result3, mock_result4, mock_result5])
+    backend = MockBackend()
+    simple_rule_based_analyzer = SimpleRuleBasedAnalyzer(backend, 0.2, 0.2, 0.2, 0.2)
+    Analyzer.init(database, backend, None, simple_rule_based_analyzer)
+    Analyzer.simple_rule_based_analysis(1)
+
+    assert backend.alerts == []
+
+# Backups with a diff of exactly one hour trigger no alert
+def test_alert_time_on_the_limit():
+    mock_result1 = _create_mock_result("foo", "1", "F", 100_000_000, datetime.fromisoformat("2000-01-01T12:00:00"))
+    mock_result2 = _create_mock_result("foo", "2", "F", 100_000_000, datetime.fromisoformat("2000-01-02T13:00:00"))
+
+    database = MockDatabase([mock_result1, mock_result2])
+    backend = MockBackend()
+    simple_rule_based_analyzer = SimpleRuleBasedAnalyzer(backend, 0.2, 0.2, 0.2, 0.2)
+    Analyzer.init(database, backend, None, simple_rule_based_analyzer)
+    Analyzer.simple_rule_based_analysis(1)
+
+    assert backend.alerts == []
+
+# Check if all past backups are considered as a reference
+def test_alert_moving_schedule():
+    mock_result1 = _create_mock_result("foo", "1", "F", 100_000_000, datetime.fromisoformat("2000-01-01T12:00:00"))
+    mock_result2 = _create_mock_result("foo", "2", "F", 100_000_000, datetime.fromisoformat("2000-02-01T13:00:00"))
+    mock_result3 = _create_mock_result("foo", "3", "F", 100_000_000, datetime.fromisoformat("2000-03-01T14:00:00"))
+    mock_result4 = _create_mock_result("foo", "4", "F", 100_000_000, datetime.fromisoformat("2000-04-01T14:30:00"))
+    mock_result5 = _create_mock_result("foo", "5", "F", 100_000_000, datetime.fromisoformat("2000-05-01T15:30:00"))
+
+    database = MockDatabase([mock_result1, mock_result2, mock_result3, mock_result4, mock_result5])
+    backend = MockBackend()
+    simple_rule_based_analyzer = SimpleRuleBasedAnalyzer(backend, 0.2, 0.2, 0.2, 0.2)
+    Analyzer.init(database, backend, None, simple_rule_based_analyzer)
+    Analyzer.simple_rule_based_analysis(1)
+
+    assert backend.alerts == []
+
+# Check behaviour around midnight
+def test_alert_time_midnight_no_alert():
+    mock_result1 = _create_mock_result("foo", "1", "F", 100_000_000, datetime.fromisoformat("2000-01-01T00:00:00"))
+    mock_result2 = _create_mock_result("foo", "2", "F", 100_000_000, datetime.fromisoformat("2000-01-01T23:30:00"))
+    mock_result3 = _create_mock_result("foo", "3", "F", 100_000_000, datetime.fromisoformat("2000-02-02T00:30:00"))
+    mock_result4 = _create_mock_result("foo", "4", "F", 100_000_000, datetime.fromisoformat("2000-01-02T23:00:00"))
+    mock_result5 = _create_mock_result("foo", "5", "F", 100_000_000, datetime.fromisoformat("2000-01-03T01:00:00"))
+
+    database = MockDatabase([mock_result1, mock_result2, mock_result3, mock_result4, mock_result5])
+    backend = MockBackend()
+    simple_rule_based_analyzer = SimpleRuleBasedAnalyzer(backend, 0.2, 0.2, 0.2, 0.2)
+    Analyzer.init(database, backend, None, simple_rule_based_analyzer)
+    Analyzer.simple_rule_based_analysis(1)
+
+    assert backend.alerts == []
+
+# Alerts should be triggered when the diff is greater than one hour
+def test_alert_unusual_time():
+    mock_result1 = _create_mock_result("foo", "1", "F", 100_000_000, datetime.fromisoformat("2000-01-01T12:00:00"))
+    mock_result2 = _create_mock_result("foo", "2", "F", 100_000_000, datetime.fromisoformat("2000-01-02T12:00:00"))
+    mock_result3 = _create_mock_result("foo", "3", "F", 100_000_000, datetime.fromisoformat("2000-01-03T12:00:00"))
+    mock_result4 = _create_mock_result("foo", "4", "F", 100_000_000, datetime.fromisoformat("2000-01-04T18:00:00"))
+
+    database = MockDatabase([mock_result1, mock_result2, mock_result3, mock_result4])
+    backend = MockBackend()
+    simple_rule_based_analyzer = SimpleRuleBasedAnalyzer(backend, 0.2, 0.2, 0.2, 0.2)
+    Analyzer.init(database, backend, None, simple_rule_based_analyzer)
+    Analyzer.simple_rule_based_analysis(1)
+
+    assert backend.alerts == [{
+        "date": mock_result4.start_time,
+        "referenceDate": datetime.fromisoformat("2000-01-04T12:00:00"),
+        "backupId": mock_result4.uuid
+    }]
+
+# Two different schedules should trigger one alert for the first backup of the second schedule
+def test_alert_two_different_schedules_same_task():
+    mock_result1 = _create_mock_result("foo", "1", "F", 100_000_000, datetime.fromisoformat("2020-12-24T18:00:00"))
+    mock_result2 = _create_mock_result("foo", "2", "F", 100_000_000, datetime.fromisoformat("2020-12-25T06:00:00"))
+    mock_result3 = _create_mock_result("foo", "3", "F", 100_000_000, datetime.fromisoformat("2020-12-26T18:00:00"))
+    mock_result4 = _create_mock_result("foo", "4", "F", 100_000_000, datetime.fromisoformat("2020-12-27T06:00:00"))
+
+    database = MockDatabase([mock_result1, mock_result2, mock_result3, mock_result4])
+    backend = MockBackend()
+    simple_rule_based_analyzer = SimpleRuleBasedAnalyzer(backend, 0.2, 0.2, 0.2, 0.2)
+    Analyzer.init(database, backend, None, simple_rule_based_analyzer)
+    Analyzer.simple_rule_based_analysis(1)
+
+    assert backend.alerts == [{
+        "date": mock_result2.start_time,
+        "referenceDate": datetime.fromisoformat("2020-12-25T18:00:00"),
+        "backupId": mock_result2.uuid
+    }]
+
+# Check behaviour around midnight
+def test_alert_time_midnight_alerts():
+    mock_result1 = _create_mock_result("foo", "1", "F", 100_000_000, datetime.fromisoformat("2000-01-01T00:00:00"))
+    mock_result2 = _create_mock_result("foo", "2", "F", 100_000_000, datetime.fromisoformat("2000-01-02T02:00:00"))
+    mock_result3 = _create_mock_result("foo", "3", "F", 100_000_000, datetime.fromisoformat("2000-01-03T22:59:00"))
+
+    database = MockDatabase([mock_result1, mock_result2, mock_result3])
+    backend = MockBackend()
+    simple_rule_based_analyzer = SimpleRuleBasedAnalyzer(backend, 0.2, 0.2, 0.2, 0.2)
+    Analyzer.init(database, backend, None, simple_rule_based_analyzer)
+    Analyzer.simple_rule_based_analysis(2)
+
+    assert backend.alerts == [{
+        "date": mock_result2.start_time,
+        "referenceDate": datetime.fromisoformat("2000-01-02T00:00:00"),
+        "backupId": mock_result2.uuid
+    }, {
+        "date": mock_result3.start_time,
+        "referenceDate": datetime.fromisoformat("2000-01-03T00:00:00"),
+        "backupId": mock_result3.uuid
+    }]

--- a/apps/analyzer/tests/test_simple_rule_based_analyzer.py
+++ b/apps/analyzer/tests/test_simple_rule_based_analyzer.py
@@ -339,7 +339,7 @@ def test_alert_exact_time():
     backend = MockBackend()
     simple_rule_based_analyzer = SimpleRuleBasedAnalyzer(backend, 0.2, 0.2, 0.2, 0.2)
     Analyzer.init(database, backend, None, simple_rule_based_analyzer)
-    Analyzer.simple_rule_based_analysis(-1)
+    Analyzer.simple_rule_based_analysis_creation_dates(-1)
 
     assert backend.alerts == []
 
@@ -355,7 +355,7 @@ def test_alert_small_time_deviation():
     backend = MockBackend()
     simple_rule_based_analyzer = SimpleRuleBasedAnalyzer(backend, 0.2, 0.2, 0.2, 0.2)
     Analyzer.init(database, backend, None, simple_rule_based_analyzer)
-    Analyzer.simple_rule_based_analysis(-1)
+    Analyzer.simple_rule_based_analysis_creation_dates(-1)
 
     assert backend.alerts == []
 
@@ -368,7 +368,7 @@ def test_alert_time_on_the_limit():
     backend = MockBackend()
     simple_rule_based_analyzer = SimpleRuleBasedAnalyzer(backend, 0.2, 0.2, 0.2, 0.2)
     Analyzer.init(database, backend, None, simple_rule_based_analyzer)
-    Analyzer.simple_rule_based_analysis(-1)
+    Analyzer.simple_rule_based_analysis_creation_dates(-1)
 
     assert backend.alerts == []
 
@@ -384,7 +384,7 @@ def test_alert_moving_schedule():
     backend = MockBackend()
     simple_rule_based_analyzer = SimpleRuleBasedAnalyzer(backend, 0.2, 0.2, 0.2, 0.2)
     Analyzer.init(database, backend, None, simple_rule_based_analyzer)
-    Analyzer.simple_rule_based_analysis(-1)
+    Analyzer.simple_rule_based_analysis_creation_dates(-1)
 
     assert backend.alerts == []
 
@@ -400,7 +400,7 @@ def test_alert_time_midnight_no_alert():
     backend = MockBackend()
     simple_rule_based_analyzer = SimpleRuleBasedAnalyzer(backend, 0.2, 0.2, 0.2, 0.2)
     Analyzer.init(database, backend, None, simple_rule_based_analyzer)
-    Analyzer.simple_rule_based_analysis(-1)
+    Analyzer.simple_rule_based_analysis_creation_dates(-1)
 
     assert backend.alerts == []
 
@@ -415,7 +415,7 @@ def test_alert_unusual_time():
     backend = MockBackend()
     simple_rule_based_analyzer = SimpleRuleBasedAnalyzer(backend, 0.2, 0.2, 0.2, 0.2)
     Analyzer.init(database, backend, None, simple_rule_based_analyzer)
-    Analyzer.simple_rule_based_analysis(-1)
+    Analyzer.simple_rule_based_analysis_creation_dates(-1)
 
     assert backend.alerts == [{
         "date": mock_result4.start_time,
@@ -434,7 +434,7 @@ def test_alert_two_different_schedules_same_task():
     backend = MockBackend()
     simple_rule_based_analyzer = SimpleRuleBasedAnalyzer(backend, 0.2, 0.2, 0.2, 0.2)
     Analyzer.init(database, backend, None, simple_rule_based_analyzer)
-    Analyzer.simple_rule_based_analysis(-1)
+    Analyzer.simple_rule_based_analysis_creation_dates(-1)
 
     assert backend.alerts == [{
         "date": mock_result2.start_time,
@@ -452,7 +452,7 @@ def test_alert_time_midnight_alerts():
     backend = MockBackend()
     simple_rule_based_analyzer = SimpleRuleBasedAnalyzer(backend, 0.2, 0.2, 0.2, 0.2)
     Analyzer.init(database, backend, None, simple_rule_based_analyzer)
-    Analyzer.simple_rule_based_analysis(-1)
+    Analyzer.simple_rule_based_analysis_creation_dates(-1)
 
     assert backend.alerts == [{
         "date": mock_result2.start_time,
@@ -475,7 +475,7 @@ def test_alert_creation_date_unordered():
     backend = MockBackend()
     simple_rule_based_analyzer = SimpleRuleBasedAnalyzer(backend, 0.2, 0.2, 0.2, 0.2)
     Analyzer.init(database, backend, None, simple_rule_based_analyzer)
-    Analyzer.simple_rule_based_analysis(-1)
+    Analyzer.simple_rule_based_analysis_creation_dates(-1)
 
     assert backend.alerts == [{
         "date": mock_result2.start_time,
@@ -498,7 +498,7 @@ def test_alert_creation_date_different_tasks():
     backend = MockBackend()
     simple_rule_based_analyzer = SimpleRuleBasedAnalyzer(backend, 0.2, 0.2, 0.2, 0.2)
     Analyzer.init(database, backend, None, simple_rule_based_analyzer)
-    Analyzer.simple_rule_based_analysis(-1)
+    Analyzer.simple_rule_based_analysis_creation_dates(-1)
 
     assert backend.alerts == [{
         "date": mock_result4.start_time,

--- a/apps/analyzer/tests/test_simple_rule_based_analyzer.py
+++ b/apps/analyzer/tests/test_simple_rule_based_analyzer.py
@@ -569,7 +569,7 @@ def test_alert_latest_creation_date():
 
     database = MockDatabase([mock_result1, mock_result2, mock_result3, mock_result4])
     backend = MockBackend()
-    backend.set_latest_creation_date_alert("3")
+    backend.set_latest_alert_id("CREATION_DATE_ALERT", None, "3")
     simple_rule_based_analyzer = SimpleRuleBasedAnalyzer(backend, 0.2, 0.2, 0.2, 0.2)
     Analyzer.init(database, backend, None, simple_rule_based_analyzer)
     Analyzer.simple_rule_based_analysis_creation_dates(-1)

--- a/apps/analyzer/tests/test_simple_rule_based_analyzer.py
+++ b/apps/analyzer/tests/test_simple_rule_based_analyzer.py
@@ -341,7 +341,7 @@ def test_alert_exact_time():
     Analyzer.init(database, backend, None, simple_rule_based_analyzer)
     Analyzer.simple_rule_based_analysis_creation_dates(-1)
 
-    assert backend.alerts == []
+    assert backend.creation_date_alerts == []
 
 # Deviations up to 15 mins from the first backup
 def test_alert_small_time_deviation():
@@ -357,7 +357,7 @@ def test_alert_small_time_deviation():
     Analyzer.init(database, backend, None, simple_rule_based_analyzer)
     Analyzer.simple_rule_based_analysis_creation_dates(-1)
 
-    assert backend.alerts == []
+    assert backend.creation_date_alerts == []
 
 # Backups with a diff of exactly one hour trigger no alert
 def test_alert_time_on_the_limit():
@@ -370,7 +370,7 @@ def test_alert_time_on_the_limit():
     Analyzer.init(database, backend, None, simple_rule_based_analyzer)
     Analyzer.simple_rule_based_analysis_creation_dates(-1)
 
-    assert backend.alerts == []
+    assert backend.creation_date_alerts == []
 
 # Check if all past backups are considered as a reference
 def test_alert_moving_schedule():
@@ -386,7 +386,7 @@ def test_alert_moving_schedule():
     Analyzer.init(database, backend, None, simple_rule_based_analyzer)
     Analyzer.simple_rule_based_analysis_creation_dates(-1)
 
-    assert backend.alerts == []
+    assert backend.creation_date_alerts == []
 
 # Check behaviour around midnight
 def test_alert_time_midnight_no_alert():
@@ -402,7 +402,7 @@ def test_alert_time_midnight_no_alert():
     Analyzer.init(database, backend, None, simple_rule_based_analyzer)
     Analyzer.simple_rule_based_analysis_creation_dates(-1)
 
-    assert backend.alerts == []
+    assert backend.creation_date_alerts == []
 
 # Alerts should be triggered when the diff is greater than one hour
 def test_alert_unusual_time():
@@ -417,9 +417,9 @@ def test_alert_unusual_time():
     Analyzer.init(database, backend, None, simple_rule_based_analyzer)
     Analyzer.simple_rule_based_analysis_creation_dates(-1)
 
-    assert backend.alerts == [{
-        "date": mock_result4.start_time,
-        "referenceDate": datetime.fromisoformat("2000-01-04T12:00:00"),
+    assert backend.creation_date_alerts == [{
+        "date": mock_result4.start_time.isoformat(),
+        "referenceDate": "2000-01-04T12:00:00",
         "backupId": mock_result4.uuid
     }]
 
@@ -436,9 +436,9 @@ def test_alert_two_different_schedules_same_task():
     Analyzer.init(database, backend, None, simple_rule_based_analyzer)
     Analyzer.simple_rule_based_analysis_creation_dates(-1)
 
-    assert backend.alerts == [{
-        "date": mock_result2.start_time,
-        "referenceDate": datetime.fromisoformat("2020-12-25T18:00:00"),
+    assert backend.creation_date_alerts == [{
+        "date": mock_result2.start_time.isoformat(),
+        "referenceDate": "2020-12-25T18:00:00",
         "backupId": mock_result2.uuid
     }]
 
@@ -454,13 +454,13 @@ def test_alert_time_midnight_alerts():
     Analyzer.init(database, backend, None, simple_rule_based_analyzer)
     Analyzer.simple_rule_based_analysis_creation_dates(-1)
 
-    assert backend.alerts == [{
-        "date": mock_result2.start_time,
-        "referenceDate": datetime.fromisoformat("2000-01-02T00:00:00"),
+    assert backend.creation_date_alerts == [{
+        "date": mock_result2.start_time.isoformat(),
+        "referenceDate": "2000-01-02T00:00:00",
         "backupId": mock_result2.uuid
     }, {
-        "date": mock_result3.start_time,
-        "referenceDate": datetime.fromisoformat("2000-01-03T00:00:00"),
+        "date": mock_result3.start_time.isoformat(),
+        "referenceDate": "2000-01-03T00:00:00",
         "backupId": mock_result3.uuid
     }]
 
@@ -477,13 +477,13 @@ def test_alert_creation_date_unordered():
     Analyzer.init(database, backend, None, simple_rule_based_analyzer)
     Analyzer.simple_rule_based_analysis_creation_dates(-1)
 
-    assert backend.alerts == [{
-        "date": mock_result2.start_time,
-        "referenceDate": datetime.fromisoformat("2020-01-02T18:00:00"),
+    assert backend.creation_date_alerts == [{
+        "date": mock_result2.start_time.isoformat(),
+        "referenceDate": "2020-01-02T18:00:00",
         "backupId": mock_result2.uuid
     }, {
-        "date": mock_result4.start_time,
-        "referenceDate": datetime.fromisoformat("2020-01-04T18:30:00"),
+        "date": mock_result4.start_time.isoformat(),
+        "referenceDate": "2020-01-04T18:30:00",
         "backupId": mock_result4.uuid
     }]
 
@@ -500,8 +500,8 @@ def test_alert_creation_date_different_tasks():
     Analyzer.init(database, backend, None, simple_rule_based_analyzer)
     Analyzer.simple_rule_based_analysis_creation_dates(-1)
 
-    assert backend.alerts == [{
-        "date": mock_result4.start_time,
-        "referenceDate": datetime.fromisoformat("2020-01-02T19:00:00"),
+    assert backend.creation_date_alerts == [{
+        "date": mock_result4.start_time.isoformat(),
+        "referenceDate": "2020-01-02T19:00:00",
         "backupId": mock_result4.uuid
     }]


### PR DESCRIPTION
Adds a new analysis mode to the analyzer: Alerts based on the time of the creation of backups
If a 'full' backup is created at a time where no previous backup in the same task has been created with a tolerance of one hour, the analyzer sends a corresponding alert to the backend. 