### PR TITLE
125 backend module filter backup data by backup tasks ids

### DIFF
--- a/apps/backend/src/app/app.module.ts
+++ b/apps/backend/src/app/app.module.ts
@@ -1,29 +1,30 @@
-import {Module} from '@nestjs/common';
-import {ConfigModule} from '@nestjs/config';
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 
-import {AppController} from './app.controller';
-import {AppService} from './app.service';
-import {TypeOrmModule} from '@nestjs/typeorm';
-import {DbConfigService} from "./db-config.service";
-import {DemoModule} from "./demo/demo.module";
-import {BackupDataModule} from "./backupData/backupData.module";
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DbConfigService } from './db-config.service';
+import { DemoModule } from './demo/demo.module';
+import { BackupDataModule } from './backupData/backupData.module';
 import { AlertingModule } from './alerting/alerting.module';
+import { TasksModule } from './tasks/tasks.module';
 
 @Module({
-    imports: [
-        ConfigModule.forRoot({
-            isGlobal: true,
-        }),
-        TypeOrmModule.forRootAsync({
-            imports: [ConfigModule],
-            useClass: DbConfigService,
-        }),
-        DemoModule,
-        BackupDataModule,
-        AlertingModule
-    ],
-    controllers: [AppController],
-    providers: [AppService],
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+    }),
+    TypeOrmModule.forRootAsync({
+      imports: [ConfigModule],
+      useClass: DbConfigService,
+    }),
+    DemoModule,
+    BackupDataModule,
+    AlertingModule,
+    TasksModule,
+  ],
+  controllers: [AppController],
+  providers: [AppService],
 })
-export class AppModule {
-}
+export class AppModule {}

--- a/apps/backend/src/app/backupData/backupData.controller.spec.ts
+++ b/apps/backend/src/app/backupData/backupData.controller.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import request from 'supertest';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { ILike, Repository } from 'typeorm';
 import { BackupDataEntity } from './entity/backupData.entity';
 import { CreateBackupDataDto } from './dto/createBackupData.dto';
 import { BackupDataModule } from './backupData.module';
@@ -137,6 +137,30 @@ describe('BackupDataController (e2e)', () => {
     expect(mockBackupDataRepository.findAndCount).toBeCalledWith({
       order: { creationDate: 'DESC' },
       where: { creationDate: expect.any(Object), type: BackupType.FULL },
+    });
+  });
+  it('/backupData (GET) with taskId should return backup data entries with the specified taskId', async () => {
+    await request(app.getHttpServer())
+      .get('/backupData?taskId=task-123')
+      .expect(200);
+
+    expect(mockBackupDataRepository.findAndCount).toBeCalledWith({
+      order: { creationDate: 'DESC' },
+      where: { taskId: { id: 'task-123' }, type: BackupType.FULL },
+    });
+  });
+
+  it('/backupData (GET) with taskName should return backup data entries with the specified taskName', async () => {
+    await request(app.getHttpServer())
+      .get('/backupData?taskName=backup-task')
+      .expect(200);
+
+    expect(mockBackupDataRepository.findAndCount).toBeCalledWith({
+      order: { creationDate: 'DESC' },
+      where: {
+        taskId: { displayName: ILike('%backup-task%') },
+        type: BackupType.FULL,
+      },
     });
   });
 });

--- a/apps/backend/src/app/backupData/backupData.service.spec.ts
+++ b/apps/backend/src/app/backupData/backupData.service.spec.ts
@@ -124,6 +124,24 @@ describe('BackupDataService', () => {
         BadRequestException
       );
     });
+
+    it('should create a where clause for taskId search', () => {
+      const filterDto: BackupDataFilterDto = { taskId: 'task-123' };
+      const where = service.createWhereClause(filterDto);
+      expect(where).toEqual({
+        taskId: { id: 'task-123' },
+        type: BackupType.FULL,
+      });
+    });
+
+    it('should create a where clause for taskName search', () => {
+      const filterDto: BackupDataFilterDto = { taskName: 'backup-task' };
+      const where = service.createWhereClause(filterDto);
+      expect(where).toEqual({
+        taskId: { displayName: ILike('%backup-task%') },
+        type: BackupType.FULL,
+      });
+    });
   });
 
   describe('createOrderClause', () => {
@@ -151,7 +169,8 @@ describe('BackupDataService', () => {
 
   describe('create', () => {
     it('should create a new backup data entity', async () => {
-      let createBackupDataDto: CreateBackupDataDto = new CreateBackupDataDto();
+      const createBackupDataDto: CreateBackupDataDto =
+        new CreateBackupDataDto();
       Object.assign(createBackupDataDto, mockBackupDataEntity);
 
       const result = await service.create(createBackupDataDto);

--- a/apps/backend/src/app/backupData/backupData.service.ts
+++ b/apps/backend/src/app/backupData/backupData.service.ts
@@ -2,6 +2,7 @@ import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import {
   Between,
+  FindOptionsWhere,
   ILike,
   LessThanOrEqual,
   MoreThanOrEqual,
@@ -21,7 +22,7 @@ import { BackupType } from './dto/backupType';
 export class BackupDataService extends PaginationService {
   constructor(
     @InjectRepository(BackupDataEntity)
-    private backupDataRepository: Repository<BackupDataEntity>
+    private readonly backupDataRepository: Repository<BackupDataEntity>
   ) {
     super();
   }
@@ -79,7 +80,7 @@ export class BackupDataService extends PaginationService {
    * @param backupDataFilterDto
    */
   createWhereClause(backupDataFilterDto: BackupDataFilterDto) {
-    let where: any = {};
+    const where: FindOptionsWhere<BackupDataEntity> = {};
 
     //ID search
     if (backupDataFilterDto.id) {
@@ -136,6 +137,18 @@ export class BackupDataService extends PaginationService {
       where.sizeMB = MoreThanOrEqual(backupDataFilterDto.fromSizeMB);
     } else if (backupDataFilterDto.toSizeMB) {
       where.sizeMB = LessThanOrEqual(backupDataFilterDto.toSizeMB);
+    }
+
+    //Task id search
+    if (backupDataFilterDto.taskId) {
+      where.taskId = { id: backupDataFilterDto.taskId };
+    }
+
+    //Task name search
+    if (backupDataFilterDto.taskName) {
+      where.taskId = {
+        displayName: ILike(`%${backupDataFilterDto.taskName}%`),
+      };
     }
 
     where.type = BackupType.FULL;

--- a/apps/backend/src/app/backupData/dto/backupDataFilter.dto.ts
+++ b/apps/backend/src/app/backupData/dto/backupDataFilter.dto.ts
@@ -1,4 +1,4 @@
-import { IsDate, IsInt, IsOptional, IsString } from 'class-validator';
+import { IsOptional, IsString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class BackupDataFilterDto {
@@ -39,4 +39,18 @@ export class BackupDataFilterDto {
   })
   @IsOptional()
   toSizeMB?: number;
+
+  @ApiProperty({
+    description: 'Task id',
+    required: false,
+  })
+  @IsOptional()
+  taskId?: string;
+
+  @ApiProperty({
+    description: 'Task name',
+    required: false,
+  })
+  @IsOptional()
+  taskName?: string;
 }

--- a/apps/backend/src/app/backupData/dto/createBackupData.dto.ts
+++ b/apps/backend/src/app/backupData/dto/createBackupData.dto.ts
@@ -1,5 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsDateString, IsEnum, IsNumber, IsOptional, IsString, IsUUID } from 'class-validator';
+import {
+  IsDateString,
+  IsEnum,
+  IsNumber,
+  IsOptional,
+  IsUUID,
+} from 'class-validator';
 import { BackupType } from './backupType';
 
 export class CreateBackupDataDto {
@@ -23,7 +29,7 @@ export class CreateBackupDataDto {
     nullable: false,
     required: true,
     enum: BackupType,
-    default: BackupType.FULL
+    default: BackupType.FULL,
   })
   @IsOptional()
   @IsEnum(BackupType)
@@ -36,4 +42,11 @@ export class CreateBackupDataDto {
   })
   @IsDateString({ strict: true })
   creationDate!: Date;
+
+  @ApiProperty({
+    description: 'Task Id',
+    nullable: true,
+    required: false,
+  })
+  taskId?: string;
 }

--- a/apps/backend/src/app/backupData/entity/backupData.entity.ts
+++ b/apps/backend/src/app/backupData/entity/backupData.entity.ts
@@ -46,5 +46,5 @@ export class BackupDataEntity {
     eager: true,
   })
   @JoinColumn({ name: 'taskId', referencedColumnName: 'id' })
-  task!: TaskEntity;
+  taskId?: TaskEntity;
 }

--- a/apps/backend/src/app/backupData/entity/backupData.entity.ts
+++ b/apps/backend/src/app/backupData/entity/backupData.entity.ts
@@ -1,6 +1,7 @@
-import { Column, Entity, PrimaryColumn } from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 import { BackupType } from '../dto/backupType';
+import { TaskEntity } from '../../tasks/entity/task.entity';
 
 @Entity('BackupData')
 export class BackupDataEntity {
@@ -37,6 +38,13 @@ export class BackupDataEntity {
     nullable: false,
     required: true,
   })
-  @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+  @Column({ type: 'timestamp' })
   creationDate!: Date;
+
+  @ManyToOne(() => TaskEntity, {
+    nullable: true,
+    eager: true,
+  })
+  @JoinColumn({ name: 'taskId', referencedColumnName: 'id' })
+  task!: TaskEntity;
 }

--- a/apps/backend/src/app/db-config.service.ts
+++ b/apps/backend/src/app/db-config.service.ts
@@ -18,6 +18,8 @@ import { SizeAlertEntity } from './alerting/entity/alerts/sizeAlert.entity';
 import { NewAlertStructure1732887680122 } from './migrations/1732887680122-NewAlertStructure';
 import { CreationDateAlertEntity } from './alerting/entity/alerts/creationDateAlert.entity';
 import { CreationDateAlert1733070019992 } from './migrations/1733070019992-CreationDateAlert';
+import { TaskEntity } from './tasks/entity/task.entity';
+import { Tasks1733397652480 } from './migrations/1733397652480-Tasks';
 
 /**
  * Used by NestJS to reach database.
@@ -26,7 +28,7 @@ import { CreationDateAlert1733070019992 } from './migrations/1733070019992-Creat
 export class DbConfigService implements TypeOrmOptionsFactory {
   constructor(
     @Inject(ConfigService)
-    private configService: ConfigService
+    private readonly configService: ConfigService
   ) {}
 
   createTypeOrmOptions(): TypeOrmModuleOptions & DataSourceOptions {
@@ -43,6 +45,7 @@ export class DbConfigService implements TypeOrmOptionsFactory {
         AlertTypeEntity,
         SizeAlertEntity,
         CreationDateAlertEntity,
+        TaskEntity,
       ],
       migrationsRun: true,
       migrations: [
@@ -57,6 +60,7 @@ export class DbConfigService implements TypeOrmOptionsFactory {
         AlertTypeNameUnique1732874749343,
         NewAlertStructure1732887680122,
         CreationDateAlert1733070019992,
+        Tasks1733397652480,
       ],
       logging: true,
     };

--- a/apps/backend/src/app/migrations/1733397652480-Tasks.ts
+++ b/apps/backend/src/app/migrations/1733397652480-Tasks.ts
@@ -1,0 +1,26 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Tasks1733397652480 implements MigrationInterface {
+  name = 'Tasks1733397652480';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`CREATE TABLE "Task"
+                             (
+                                 "id"          character varying NOT NULL,
+                                 "displayName" character varying NOT NULL,
+                                 CONSTRAINT "PK_95d9364b8115119ba8b15a43592" PRIMARY KEY ("id")
+                             )`);
+    await queryRunner.query(`ALTER TABLE "BackupData"
+        ADD "taskId" character varying`);
+    await queryRunner.query(`ALTER TABLE "BackupData"
+        ADD CONSTRAINT "FK_7e97960e3f81eeb4cf39a087f02" FOREIGN KEY ("taskId") REFERENCES "Task" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "BackupData" DROP CONSTRAINT "FK_7e97960e3f81eeb4cf39a087f02"`
+    );
+    await queryRunner.query(`ALTER TABLE "BackupData" DROP COLUMN "taskId"`);
+    await queryRunner.query(`DROP TABLE "Task"`);
+  }
+}

--- a/apps/backend/src/app/tasks/dto/createTask.dto.ts
+++ b/apps/backend/src/app/tasks/dto/createTask.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+
+export class CreateTaskDto {
+  @ApiProperty({
+    description: 'Uuid',
+    required: true,
+  })
+  @IsString()
+  id!: string;
+
+  @ApiProperty({
+    description: 'Display name',
+    required: true,
+  })
+  displayName!: string;
+}

--- a/apps/backend/src/app/tasks/entity/task.entity.ts
+++ b/apps/backend/src/app/tasks/entity/task.entity.ts
@@ -1,0 +1,19 @@
+import { Column, Entity, PrimaryColumn } from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
+
+@Entity('Task')
+export class TaskEntity {
+  @ApiProperty({
+    description: 'Uuid',
+    required: true,
+  })
+  @PrimaryColumn()
+  id!: string;
+
+  @ApiProperty({
+    description: 'Display name',
+    required: true,
+  })
+  @Column({ nullable: false })
+  displayName!: string;
+}

--- a/apps/backend/src/app/tasks/tasks.controller.spec.ts
+++ b/apps/backend/src/app/tasks/tasks.controller.spec.ts
@@ -1,0 +1,89 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { TasksController } from './tasks.controller';
+import { TasksService } from './tasks.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { TaskEntity } from './entity/task.entity';
+import { Repository } from 'typeorm';
+import { CreateTaskDto } from './dto/createTask.dto';
+
+describe('TasksController (e2e)', () => {
+  let app: INestApplication;
+  let repository: Repository<TaskEntity>;
+
+  const mockTaskRepository = {
+    find: jest.fn(),
+    findOneBy: jest.fn(),
+    save: jest.fn(),
+  };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      controllers: [TasksController],
+      providers: [
+        TasksService,
+        {
+          provide: getRepositoryToken(TaskEntity),
+          useValue: mockTaskRepository,
+        },
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+    repository = moduleFixture.get<Repository<TaskEntity>>(getRepositoryToken(TaskEntity));
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('/tasks (GET) should return an array of tasks', async () => {
+    const result = [new TaskEntity()];
+    jest.spyOn(repository, 'find').mockResolvedValue(result);
+
+    const response = await request(app.getHttpServer())
+      .get('/tasks')
+      .expect(200);
+
+    expect(response.body).toEqual(result);
+  });
+
+  it('/tasks/:id (GET) should return a task if found', async () => {
+    const id = 'ea1a2f52-5cf4-44a6-b266-175ee396a18c';
+    const task = new TaskEntity();
+    jest.spyOn(repository, 'findOneBy').mockResolvedValue(task);
+
+    const response = await request(app.getHttpServer())
+      .get(`/tasks/${id}`)
+      .expect(200);
+
+    expect(response.body).toEqual(task);
+  });
+
+  it('/tasks/:id (GET) should throw a NotFoundException if task not found', async () => {
+    const id = 'ea1a2f52-5cf4-44a6-b266-175ee396a18e';
+    jest.spyOn(repository, 'findOneBy').mockResolvedValue(null);
+
+    await request(app.getHttpServer())
+      .get(`/tasks/${id}`)
+      .expect(404);
+  });
+
+  it('/tasks (POST) should create and return a task', async () => {
+    const createTaskDto: CreateTaskDto = {
+      id: 'someId',
+      displayName: 'someName',
+    };
+    const task = new TaskEntity();
+    jest.spyOn(repository, 'save').mockResolvedValue(task);
+
+    const response = await request(app.getHttpServer())
+      .post('/tasks')
+      .send(createTaskDto)
+      .expect(201);
+
+    expect(response.body).toEqual(task);
+  });
+});

--- a/apps/backend/src/app/tasks/tasks.controller.ts
+++ b/apps/backend/src/app/tasks/tasks.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Get, Logger, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Logger,
+  Param,
+  ParseUUIDPipe,
+  Post,
+} from '@nestjs/common';
 import {
   ApiCreatedResponse,
   ApiNotFoundResponse,
@@ -27,7 +35,7 @@ export class TasksController {
   @ApiOperation({ summary: 'Returns the task with the given id.' })
   @ApiOkResponse()
   @ApiNotFoundResponse()
-  async findOne(id: string) {
+  async findOne(@Param('id', ParseUUIDPipe) id: string) {
     return this.tasksService.findOne(id);
   }
 

--- a/apps/backend/src/app/tasks/tasks.controller.ts
+++ b/apps/backend/src/app/tasks/tasks.controller.ts
@@ -1,10 +1,40 @@
-import { Controller, Logger } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { Body, Controller, Get, Logger, Post } from '@nestjs/common';
+import {
+  ApiCreatedResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+import { TasksService } from './tasks.service';
+import { CreateTaskDto } from './dto/createTask.dto';
 
 @ApiTags('Tasks')
 @Controller('tasks')
 export class TasksController {
   readonly logger = new Logger(TasksController.name);
 
-  constructor(private readonly tasksController: TasksController) {}
+  constructor(private readonly tasksService: TasksService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Returns all tasks.' })
+  @ApiOkResponse()
+  async findAll() {
+    return this.tasksService.findAll();
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Returns the task with the given id.' })
+  @ApiOkResponse()
+  @ApiNotFoundResponse()
+  async findOne(id: string) {
+    return this.tasksService.findOne(id);
+  }
+
+  @Post()
+  @ApiOperation({ summary: 'Creates a new task.' })
+  @ApiCreatedResponse()
+  async create(@Body() createTaskDto: CreateTaskDto) {
+    return this.tasksService.create(createTaskDto);
+  }
 }

--- a/apps/backend/src/app/tasks/tasks.controller.ts
+++ b/apps/backend/src/app/tasks/tasks.controller.ts
@@ -1,0 +1,10 @@
+import { Controller, Logger } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+
+@ApiTags('Tasks')
+@Controller('tasks')
+export class TasksController {
+  readonly logger = new Logger(TasksController.name);
+
+  constructor(private readonly tasksController: TasksController) {}
+}

--- a/apps/backend/src/app/tasks/tasks.module.ts
+++ b/apps/backend/src/app/tasks/tasks.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
 import { TasksService } from './tasks.service';
 import { TasksController } from './tasks.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TaskEntity } from './entity/task.entity';
 
 @Module({
   providers: [TasksService],
-  imports: [],
+  imports: [TypeOrmModule.forFeature([TaskEntity])],
   controllers: [TasksController],
   exports: [TasksService],
 })

--- a/apps/backend/src/app/tasks/tasks.module.ts
+++ b/apps/backend/src/app/tasks/tasks.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { TasksService } from './tasks.service';
+import { TasksController } from './tasks.controller';
+
+@Module({
+  providers: [TasksService],
+  imports: [],
+  controllers: [TasksController],
+  exports: [TasksService],
+})
+export class TasksModule {}

--- a/apps/backend/src/app/tasks/tasks.service.spec.ts
+++ b/apps/backend/src/app/tasks/tasks.service.spec.ts
@@ -1,0 +1,73 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { TasksService } from './tasks.service';
+import { TaskEntity } from './entity/task.entity';
+
+describe('TasksService', () => {
+  let service: TasksService;
+  let repository: Repository<TaskEntity>;
+
+  const mockTaskRepository = {
+    find: jest.fn(),
+    findOneBy: jest.fn(),
+    save: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TasksService,
+        {
+          provide: getRepositoryToken(TaskEntity),
+          useValue: mockTaskRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<TasksService>(TasksService);
+    repository = module.get<Repository<TaskEntity>>(
+      getRepositoryToken(TaskEntity)
+    );
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('findAll', () => {
+    it('should return an array of tasks', async () => {
+      const result = [new TaskEntity()];
+      jest.spyOn(repository, 'find').mockResolvedValue(result);
+
+      expect(await service.findAll()).toBe(result);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a task if found', async () => {
+      const id = 'ea1a2f52-5cf4-44a6-b266-175ee396a18c';
+      const task = new TaskEntity();
+      jest.spyOn(repository, 'findOneBy').mockResolvedValue(task);
+
+      expect(await service.findOne(id)).toBe(task);
+    });
+
+    it('should throw a NotFoundException if task not found', async () => {
+      const id = 'ea1a2f52-5cf4-44a6-b266-175ee396a18d';
+      jest.spyOn(repository, 'findOneBy').mockResolvedValue(null);
+
+      await expect(service.findOne(id)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('create', () => {
+    it('should create and return a task', async () => {
+      const task = new TaskEntity();
+      jest.spyOn(repository, 'save').mockResolvedValue(task);
+
+      expect(await service.create(task)).toBe(task);
+    });
+  });
+});

--- a/apps/backend/src/app/tasks/tasks.service.ts
+++ b/apps/backend/src/app/tasks/tasks.service.ts
@@ -1,0 +1,6 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class TasksService {
+  constructor() {}
+}

--- a/apps/backend/src/app/tasks/tasks.service.ts
+++ b/apps/backend/src/app/tasks/tasks.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { TaskEntity } from './entity/task.entity';
 import { Repository } from 'typeorm';
@@ -14,8 +14,12 @@ export class TasksService {
     return this.taskRepository.find();
   }
 
-  async findOne(id: string): Promise<TaskEntity | null> {
-    return this.taskRepository.findOneBy({ id });
+  async findOne(id: string): Promise<TaskEntity> {
+    const task = await this.taskRepository.findOneBy({ id });
+    if (!task) {
+      throw new NotFoundException(`Task with id ${id} not found`);
+    }
+    return task;
   }
 
   async create(task: TaskEntity): Promise<TaskEntity> {

--- a/apps/backend/src/app/tasks/tasks.service.ts
+++ b/apps/backend/src/app/tasks/tasks.service.ts
@@ -1,6 +1,24 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { TaskEntity } from './entity/task.entity';
+import { Repository } from 'typeorm';
 
 @Injectable()
 export class TasksService {
-  constructor() {}
+  constructor(
+    @InjectRepository(TaskEntity)
+    private readonly taskRepository: Repository<TaskEntity>
+  ) {}
+
+  async findAll(): Promise<TaskEntity[]> {
+    return this.taskRepository.find();
+  }
+
+  async findOne(id: string): Promise<TaskEntity | null> {
+    return this.taskRepository.findOneBy({ id });
+  }
+
+  async create(task: TaskEntity): Promise<TaskEntity> {
+    return this.taskRepository.save(task);
+  }
 }


### PR DESCRIPTION
Criterion 1: Each backup also consists of the backup task id stored in the dump.
Criterion 2: It exists an API which provides data about the backups depending on the backup task ids provided in the request.
Criterion 3: backend Speicher die verschiedenen Tasks mit dazu notwendigen Daten in einer Tasks Tabelle und bietet dafür eine API ans Frontend an
Criterion 4: Backend Speichert die Task ID zu den Backups.