### PR TITLE
87 frontend email notification reciever list

### DIFF
--- a/apps/frontend/src/app/app.component.html
+++ b/apps/frontend/src/app/app.component.html
@@ -12,6 +12,15 @@
             <cds-icon shape="bell"></cds-icon>
             <span class="nav-text">Notifications</span>
           </button>
+          <button clrDropdownItem>
+            <cds-icon shape="envelope"></cds-icon>
+            <span
+              routerLinkActive="active"
+              routerLink="email-receiver"
+              class="nav-text"
+              >Email Receiver</span
+            >
+          </button>
         </clr-dropdown-menu>
       </clr-dropdown>
       <app-notification-settings></app-notification-settings>

--- a/apps/frontend/src/app/app.module.ts
+++ b/apps/frontend/src/app/app.module.ts
@@ -23,6 +23,10 @@ import {
   tagIcon,
   dataClusterIcon,
   filterIcon,
+  envelopeIcon,
+  plusIcon,
+  lockIcon,
+  trashIcon,
 } from '@cds/core/icon';
 import { NgxEchartsModule } from 'ngx-echarts';
 import { TestUploadComponent } from './test-upload/component/test-upload/test-upload.component';
@@ -31,6 +35,7 @@ import { BackupsComponent } from './backups-overview/backups/backups/backups.com
 import { BASE_URL } from './shared/types/configuration';
 import { AlertComponent } from './alert/component/alert.component';
 import { NotificationSettingsComponent } from './management/components/settings/notification-settings/notification-settings.component';
+import { EmailReceiverSettingsComponent } from './management/components/settings/email-receiver-settings/email-receiver-settings.component';
 
 @NgModule({
   declarations: [
@@ -40,6 +45,7 @@ import { NotificationSettingsComponent } from './management/components/settings/
     BackupsComponent,
     AlertComponent,
     NotificationSettingsComponent,
+    EmailReceiverSettingsComponent,
   ],
   imports: [
     BrowserModule,
@@ -69,7 +75,11 @@ export class AppModule {
       angleIcon,
       tagIcon,
       dataClusterIcon,
-      filterIcon
+      filterIcon,
+      envelopeIcon,
+      plusIcon,
+      lockIcon,
+      trashIcon,
     );
   }
 }

--- a/apps/frontend/src/app/app.module.ts
+++ b/apps/frontend/src/app/app.module.ts
@@ -36,6 +36,7 @@ import { BASE_URL } from './shared/types/configuration';
 import { AlertComponent } from './alert/component/alert.component';
 import { NotificationSettingsComponent } from './management/components/settings/notification-settings/notification-settings.component';
 import { EmailReceiverSettingsComponent } from './management/components/settings/email-receiver-settings/email-receiver-settings.component';
+import { ConfirmDialogComponent } from './shared/components/confirm-dialog/component/confirm-dialog/confirm-dialog.component';
 
 @NgModule({
   declarations: [
@@ -46,6 +47,7 @@ import { EmailReceiverSettingsComponent } from './management/components/settings
     AlertComponent,
     NotificationSettingsComponent,
     EmailReceiverSettingsComponent,
+    ConfirmDialogComponent,
   ],
   imports: [
     BrowserModule,

--- a/apps/frontend/src/app/app.routes.ts
+++ b/apps/frontend/src/app/app.routes.ts
@@ -3,9 +3,12 @@ import { TestUploadComponent } from './test-upload/component/test-upload/test-up
 import { FindTestDataComponent } from './test-upload/component/find-test-data/find-test-data.component';
 import { BackupsComponent } from './backups-overview/backups/backups/backups.component';
 import { AlertComponent } from './alert/component/alert.component';
+import { EmailReceiverSettingsComponent } from './management/components/settings/email-receiver-settings/email-receiver-settings.component';
 
 export const appRoutes: Route[] = [
   { path: 'upload', component: TestUploadComponent },
   { path: 'findData', component: FindTestDataComponent },
+  { path: 'email-receiver', component: EmailReceiverSettingsComponent},
   { path: '', component: BackupsComponent },
+
 ];

--- a/apps/frontend/src/app/management/components/settings/email-receiver-settings/email-receiver-settings.component.css
+++ b/apps/frontend/src/app/management/components/settings/email-receiver-settings/email-receiver-settings.component.css
@@ -2,3 +2,6 @@
     text-align: center ;
 }
 
+.error {
+    color: red;
+}

--- a/apps/frontend/src/app/management/components/settings/email-receiver-settings/email-receiver-settings.component.css
+++ b/apps/frontend/src/app/management/components/settings/email-receiver-settings/email-receiver-settings.component.css
@@ -1,0 +1,4 @@
+.clr-dg-cell {
+    text-align: center ;
+}
+

--- a/apps/frontend/src/app/management/components/settings/email-receiver-settings/email-receiver-settings.component.html
+++ b/apps/frontend/src/app/management/components/settings/email-receiver-settings/email-receiver-settings.component.html
@@ -16,7 +16,12 @@
             <cds-icon shape="plus"></cds-icon>
             New
           </button>
-          <button type="button" class="btn btn-sm btn-danger" (click)="removeEmail(selectedEmails)" [disabled]="selectedEmails.length === 0">
+          <button
+            type="button"
+            class="btn btn-sm btn-danger"
+            (click)="removeEmail(selectedEmails)"
+            [disabled]="selectedEmails.length === 0"
+          >
             <cds-icon shape="lock"></cds-icon>
             Delete
           </button>
@@ -39,7 +44,7 @@
           </clr-dg-filter>
         </ng-container>
       </clr-dg-column>
-
+<!-- 
       <clr-dg-column [clrDgField]="'id'">
         <ng-container *clrDgHideableColumn>
           ID
@@ -56,14 +61,14 @@
           </clr-dg-filter>
         </ng-container>
       </clr-dg-column>
-
+ -->
       <clr-dg-placeholder>We couldn't find any emails!</clr-dg-placeholder>
       <clr-dg-row
         *ngFor="let email of emailsSubject$.getValue()"
         [clrDgItem]="email"
       >
-        <clr-dg-cell>{{ email.mail }}</clr-dg-cell>
-        <clr-dg-cell>{{ email.id }}</clr-dg-cell>
+        <clr-dg-cell class="clr-dg-cell">{{ email.mail }}</clr-dg-cell>
+        <!-- <clr-dg-cell>{{ email.id }}</clr-dg-cell> -->
       </clr-dg-row>
 
       <clr-dg-footer> </clr-dg-footer>
@@ -83,6 +88,9 @@
           >Please enter a valid email address</clr-control-error
         >
       </clr-input-container>
+      <div class="error" *ngIf="modalError">
+        {{ modalError }}
+      </div>
     </form>
   </div>
   <div class="modal-footer">

--- a/apps/frontend/src/app/management/components/settings/email-receiver-settings/email-receiver-settings.component.html
+++ b/apps/frontend/src/app/management/components/settings/email-receiver-settings/email-receiver-settings.component.html
@@ -1,0 +1,108 @@
+<!-- email-alerts.component.html -->
+
+<h3>Email Alert Recipients</h3>
+
+<div class="btn-group">
+  <button class="btn btn-primary" (click)="showEmailModal = true">
+    <cds-icon shape="plus"></cds-icon>
+    Add Email
+  </button>
+  <button class="btn btn-success" (click)="saveChanges()">
+    <cds-icon shape="lock"></cds-icon>
+    Save Changes
+  </button>
+</div>
+
+<div class="clr-row">
+  <div class="clr-col-lg-12 clr-col-lg-12">
+    <h3>All Backups:</h3>
+    <clr-datagrid
+      *ngIf="emailsSubject$ | async as emails"
+      [clrDgLoading]="isLoading"
+    >
+
+      <clr-dg-column [clrDgField]="'email'">
+        <ng-container *clrDgHideableColumn>
+          Email
+          <clr-dg-filter [clrDgFilter]="emailFilter">
+            <clr-input-container>
+              <label>Email:</label>
+              <input
+                clrInput
+                type="string"
+                [(ngModel)]="emailFilter.ranges.mail"
+                (ngModelChange)="emailFilter.updateRanges({ mail: $event })"
+              />
+            </clr-input-container>
+          </clr-dg-filter>
+        </ng-container>
+      </clr-dg-column>
+
+      <clr-dg-column [clrDgField]="'id'">
+        <ng-container *clrDgHideableColumn>
+          ID
+          <clr-dg-filter [clrDgFilter]="emailIdFilter">
+            <clr-input-container>
+              <label>ID:</label>
+              <input
+                clrInput
+                type="number"
+                [(ngModel)]="emailIdFilter.ranges.id"
+                (ngModelChange)="emailIdFilter.updateRanges({ id: $event })"
+              />
+            </clr-input-container>
+          </clr-dg-filter>
+        </ng-container>
+      </clr-dg-column>
+
+      <clr-dg-placeholder>We couldn't find any backups!</clr-dg-placeholder>
+      <clr-dg-row *ngFor="let email of emailsSubject$.getValue()" [clrDgItem]="email">
+        <clr-dg-cell>{{ email.mail }}</clr-dg-cell>
+        <clr-dg-cell>{{ email.id }}</clr-dg-cell>
+
+      </clr-dg-row>
+
+      <clr-dg-footer>
+
+      </clr-dg-footer>
+    </clr-datagrid>
+  </div>
+
+
+
+
+
+
+<!-- Add Email Modal -->
+<clr-modal [(clrModalOpen)]="showEmailModal">
+  <h3 class="modal-title">Add Email Recipient</h3>
+  <div class="modal-body">
+    <form clrForm [formGroup]="emailForm" (ngSubmit)="saveChanges()">
+      <clr-spinner *ngIf="isLoading"></clr-spinner>
+      <clr-input-container>
+        <label>Email Address</label>
+        <input clrInput type="email" formControlName="email" />
+        <clr-control-error
+          >Please enter a valid email address</clr-control-error
+        >
+      </clr-input-container>
+    </form>
+  </div>
+  <div class="modal-footer">
+    <button
+      type="button"
+      class="btn btn-outline"
+      (click)="showEmailModal = false"
+    >
+      Cancel
+    </button>
+    <button
+      type="button"
+      class="btn btn-primary"
+      (click)="saveChanges()"
+      [disabled]="!emailForm.valid"
+    >
+      Add
+    </button>
+  </div>
+</clr-modal>

--- a/apps/frontend/src/app/management/components/settings/email-receiver-settings/email-receiver-settings.component.html
+++ b/apps/frontend/src/app/management/components/settings/email-receiver-settings/email-receiver-settings.component.html
@@ -1,27 +1,29 @@
-<!-- email-alerts.component.html -->
-
 <h3>Email Alert Recipients</h3>
-
-<div class="btn-group">
-  <button class="btn btn-primary" (click)="showEmailModal = true">
-    <cds-icon shape="plus"></cds-icon>
-    Add Email
-  </button>
-  <button class="btn btn-success" (click)="saveChanges()">
-    <cds-icon shape="lock"></cds-icon>
-    Save Changes
-  </button>
-</div>
-
 <div class="clr-row">
   <div class="clr-col-lg-12 clr-col-lg-12">
-    <h3>All Backups:</h3>
     <clr-datagrid
       *ngIf="emailsSubject$ | async as emails"
       [clrDgLoading]="isLoading"
+      [(clrDgSelected)]="selectedEmails"
     >
+      <clr-dg-action-bar>
+        <div class="btn-group">
+          <button
+            type="button"
+            class="btn btn-sm btn-secondary"
+            (click)="showEmailModal = true"
+          >
+            <cds-icon shape="plus"></cds-icon>
+            New
+          </button>
+          <button type="button" class="btn btn-sm btn-danger" (click)="removeEmail(selectedEmails)" [disabled]="selectedEmails.length === 0">
+            <cds-icon shape="lock"></cds-icon>
+            Delete
+          </button>
+        </div>
+      </clr-dg-action-bar>
 
-      <clr-dg-column [clrDgField]="'email'">
+      <clr-dg-column [clrDgField]="'mail'">
         <ng-container *clrDgHideableColumn>
           Email
           <clr-dg-filter [clrDgFilter]="emailFilter">
@@ -46,7 +48,7 @@
               <label>ID:</label>
               <input
                 clrInput
-                type="number"
+                type="string"
                 [(ngModel)]="emailIdFilter.ranges.id"
                 (ngModelChange)="emailIdFilter.updateRanges({ id: $event })"
               />
@@ -55,25 +57,20 @@
         </ng-container>
       </clr-dg-column>
 
-      <clr-dg-placeholder>We couldn't find any backups!</clr-dg-placeholder>
-      <clr-dg-row *ngFor="let email of emailsSubject$.getValue()" [clrDgItem]="email">
+      <clr-dg-placeholder>We couldn't find any emails!</clr-dg-placeholder>
+      <clr-dg-row
+        *ngFor="let email of emailsSubject$.getValue()"
+        [clrDgItem]="email"
+      >
         <clr-dg-cell>{{ email.mail }}</clr-dg-cell>
         <clr-dg-cell>{{ email.id }}</clr-dg-cell>
-
       </clr-dg-row>
 
-      <clr-dg-footer>
-
-      </clr-dg-footer>
+      <clr-dg-footer> </clr-dg-footer>
     </clr-datagrid>
   </div>
+</div>
 
-
-
-
-
-
-<!-- Add Email Modal -->
 <clr-modal [(clrModalOpen)]="showEmailModal">
   <h3 class="modal-title">Add Email Recipient</h3>
   <div class="modal-body">

--- a/apps/frontend/src/app/management/components/settings/email-receiver-settings/email-receiver-settings.component.html
+++ b/apps/frontend/src/app/management/components/settings/email-receiver-settings/email-receiver-settings.component.html
@@ -44,31 +44,12 @@
           </clr-dg-filter>
         </ng-container>
       </clr-dg-column>
-<!-- 
-      <clr-dg-column [clrDgField]="'id'">
-        <ng-container *clrDgHideableColumn>
-          ID
-          <clr-dg-filter [clrDgFilter]="emailIdFilter">
-            <clr-input-container>
-              <label>ID:</label>
-              <input
-                clrInput
-                type="string"
-                [(ngModel)]="emailIdFilter.ranges.id"
-                (ngModelChange)="emailIdFilter.updateRanges({ id: $event })"
-              />
-            </clr-input-container>
-          </clr-dg-filter>
-        </ng-container>
-      </clr-dg-column>
- -->
       <clr-dg-placeholder>We couldn't find any emails!</clr-dg-placeholder>
       <clr-dg-row
         *ngFor="let email of emailsSubject$.getValue()"
         [clrDgItem]="email"
       >
         <clr-dg-cell class="clr-dg-cell">{{ email.mail }}</clr-dg-cell>
-        <!-- <clr-dg-cell>{{ email.id }}</clr-dg-cell> -->
       </clr-dg-row>
 
       <clr-dg-footer> </clr-dg-footer>
@@ -85,6 +66,9 @@
         <label>Email Address</label>
         <input clrInput type="email" formControlName="email" />
         <clr-control-error
+          *ngIf="
+            emailForm.get('email')?.touched && emailForm.get('email')?.invalid
+          "
           >Please enter a valid email address</clr-control-error
         >
       </clr-input-container>
@@ -94,11 +78,7 @@
     </form>
   </div>
   <div class="modal-footer">
-    <button
-      type="button"
-      class="btn btn-outline"
-      (click)="showEmailModal = false"
-    >
+    <button type="button" class="btn btn-outline" (click)="resetForm()">
       Cancel
     </button>
     <button

--- a/apps/frontend/src/app/management/components/settings/email-receiver-settings/email-receiver-settings.component.spec.ts
+++ b/apps/frontend/src/app/management/components/settings/email-receiver-settings/email-receiver-settings.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { EmailReceiverSettingsComponent } from './email-receiver-settings.component';
+
+describe('EmailReceiverSettingsComponent', () => {
+  let component: EmailReceiverSettingsComponent;
+  let fixture: ComponentFixture<EmailReceiverSettingsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [EmailReceiverSettingsComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(EmailReceiverSettingsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/apps/frontend/src/app/management/components/settings/email-receiver-settings/email-receiver-settings.component.spec.ts
+++ b/apps/frontend/src/app/management/components/settings/email-receiver-settings/email-receiver-settings.component.spec.ts
@@ -3,6 +3,7 @@ import { EmailReceiverSettingsComponent } from './email-receiver-settings.compon
 import { EmailReceiverService } from '../../../services/email-receiver/email-receiver.service';
 import { FormBuilder } from '@angular/forms';
 import { of, throwError } from 'rxjs';
+import { ConfirmDialogService } from 'apps/frontend/src/app/shared/components/confirm-dialog/service/confirm-dialog.service';
 
 describe('EmailReceiverSettingsComponent', () => {
   let component: EmailReceiverSettingsComponent;
@@ -22,12 +23,14 @@ describe('EmailReceiverSettingsComponent', () => {
         .mockReturnValue(of({ id: 3, mail: 'new@example.com' })),
     };
 
+    const confirmationServiceMock = {};
+
     component = new EmailReceiverSettingsComponent(
       new FormBuilder(),
-      emailServiceMock
+      emailServiceMock,
+      confirmationServiceMock as ConfirmDialogService
     );
   });
-
   it('should create component', () => {
     expect(component).toBeTruthy();
   });

--- a/apps/frontend/src/app/management/components/settings/email-receiver-settings/email-receiver-settings.component.spec.ts
+++ b/apps/frontend/src/app/management/components/settings/email-receiver-settings/email-receiver-settings.component.spec.ts
@@ -1,23 +1,124 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { EmailReceiverSettingsComponent } from './email-receiver-settings.component';
+import { EmailReceiverService } from '../../../services/email-receiver/email-receiver.service';
+import { FormBuilder } from '@angular/forms';
+import { of, throwError } from 'rxjs';
 
 describe('EmailReceiverSettingsComponent', () => {
   let component: EmailReceiverSettingsComponent;
-  let fixture: ComponentFixture<EmailReceiverSettingsComponent>;
+  let emailServiceMock: any;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [EmailReceiverSettingsComponent]
-    })
-    .compileComponents();
+  const mockEmails = [
+    { id: 1, mail: 'test1@example.com' },
+    { id: 2, mail: 'test2@example.com' },
+  ];
 
-    fixture = TestBed.createComponent(EmailReceiverSettingsComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+  beforeEach(() => {
+    emailServiceMock = {
+      getAllEmailReceiver: vi.fn().mockReturnValue(of(mockEmails)),
+      deleteEmail: vi.fn().mockReturnValue(of({})),
+      updateEmailReceiver: vi
+        .fn()
+        .mockReturnValue(of({ id: 3, mail: 'new@example.com' })),
+    };
+
+    component = new EmailReceiverSettingsComponent(
+      new FormBuilder(),
+      emailServiceMock
+    );
   });
 
-  it('should create', () => {
+  it('should create component', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should load email receivers on init', () => {
+    component.ngOnInit();
+    expect(emailServiceMock.getAllEmailReceiver).toHaveBeenCalled();
+    expect(component['emailsSubject$'].getValue()).toEqual(mockEmails);
+  });
+
+  it('should handle error when loading emails', () => {
+    emailServiceMock.getAllEmailReceiver = vi
+      .fn()
+      .mockReturnValue(throwError(() => new Error('Failed to load')));
+    component.ngOnInit();
+    expect(component.isLoading).toBeFalsy();
+  });
+
+  it('should remove selected emails', () => {
+    const emailsToRemove = [
+      { ...mockEmails[0], id: mockEmails[0].id.toString() },
+    ];
+    component['emailsSubject$'].next(
+      mockEmails.map((email) => ({ ...email, id: email.id.toString() }))
+    );
+
+    component.removeEmail(emailsToRemove);
+
+    expect(emailServiceMock.deleteEmail).toHaveBeenCalledWith(
+      emailsToRemove[0].id
+    );
+    expect(component['emailsSubject$'].getValue()).toEqual([
+      { ...mockEmails[1], id: mockEmails[1].id.toString() },
+    ]);
+  });
+  it('should handle error when removing emails', () => {
+    emailServiceMock.deleteEmail = vi
+      .fn()
+      .mockReturnValue(throwError(() => new Error('Failed to delete')));
+
+    const consoleSpy = vi.spyOn(console, 'error');
+    component.removeEmail([
+      { ...mockEmails[0], id: mockEmails[0].id.toString() },
+    ]);
+
+    expect(consoleSpy).toHaveBeenCalled();
+    expect(component.isLoading).toBeFalsy();
+  });
+  it('should save new email when form is valid', () => {
+    const newEmail = 'new@example.com';
+    component.emailForm.patchValue({ email: newEmail });
+
+    component.saveChanges();
+
+    expect(emailServiceMock.updateEmailReceiver).toHaveBeenCalledWith({
+      mail: newEmail,
+    });
+    expect(component.showEmailModal).toBeFalsy();
+  });
+
+  it('should handle duplicate email error', () => {
+    emailServiceMock.updateEmailReceiver = vi
+      .fn()
+      .mockReturnValue(throwError(() => ({ status: 409 })));
+
+    component.emailForm.patchValue({ email: 'duplicate@example.com' });
+    component.saveChanges();
+
+    expect(component.modalError).toBe('This email already exists');
+  });
+
+  it('should handle generic error when saving email', () => {
+    emailServiceMock.updateEmailReceiver = vi
+      .fn()
+      .mockReturnValue(throwError(() => new Error('Failed to save')));
+
+    component.emailForm.patchValue({ email: 'test@example.com' });
+    component.saveChanges();
+
+    expect(component.modalError).toBe(
+      'Failed to create email. Please try again.'
+    );
+  });
+
+  it('should clean up subscriptions on destroy', () => {
+    const nextSpy = vi.spyOn(component['destroy$'], 'next');
+    const completeSpy = vi.spyOn(component['destroy$'], 'complete');
+
+    component.ngOnDestroy();
+
+    expect(nextSpy).toHaveBeenCalled();
+    expect(completeSpy).toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/app/management/components/settings/email-receiver-settings/email-receiver-settings.component.ts
+++ b/apps/frontend/src/app/management/components/settings/email-receiver-settings/email-receiver-settings.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { EmailType } from 'apps/frontend/src/app/shared/types/email';
 import { BehaviorSubject, Observable, Subject, takeUntil } from 'rxjs';
-import { EmailReceiverService } from '../../../services/email/email-receiver.service';
+import { EmailReceiverService } from '../../../services/email-receiver/email-receiver.service';
 import { CustomEmailFilter } from './emailfilter';
 
 @Component({
@@ -14,6 +14,7 @@ export class EmailReceiverSettingsComponent {
   isLoading = false;
   emailForm: FormGroup;
   showEmailModal = false;
+  protected readonly selectedEmails: EmailType[] = [];
 
   protected emailsSubject$ = new BehaviorSubject<EmailType[]>([]);
   private readonly destroy$ = new Subject<void>();
@@ -40,11 +41,10 @@ export class EmailReceiverSettingsComponent {
   loadEmailReceiver(): void {
     this.isLoading = true;
     this.emailService
-      .getAllEmails()
+      .getAllEmailReceiver()
       .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: (emails) => {
-          console.log(emails);
           this.emailsSubject$.next(emails);
           this.isLoading = false;
         },
@@ -55,8 +55,6 @@ export class EmailReceiverSettingsComponent {
 
   addEmail() {
     if (this.emailForm.valid) {
-      // hier muss ich die communication mit backend einbauen. wiederhole eingabe,
-      //wenn email bereits in Liste vorhanden, oder die eingabe keine korrekte email ist
       this.isLoading = true;
       const newEmail = {
         email: this.emailForm.get('email')?.value,
@@ -64,17 +62,14 @@ export class EmailReceiverSettingsComponent {
 
       const currentEmails = this.emailsSubject$.getValue();
 
-      //this.emailsSubject$.next([...currentEmails, newEmail]);
       this.emailForm.reset();
       this.showEmailModal = false;
     }
   }
 
-  removeEmail(emailToRemove: EmailType) {
-    this.emailService.deleteEmail(emailToRemove);
-    /*     this.emailsSubject$.next(
-      currentEmails.filter((email) => email.id !== emailToRemove.id)
-    ); */
+  removeEmail(emailToRemove: EmailType[]) {
+    // implement forkjion ... 
+    //this.emailService.deleteEmail(emailToRemove);
   }
 
   saveChanges() {}

--- a/apps/frontend/src/app/management/components/settings/email-receiver-settings/email-receiver-settings.component.ts
+++ b/apps/frontend/src/app/management/components/settings/email-receiver-settings/email-receiver-settings.component.ts
@@ -87,7 +87,7 @@ export class EmailReceiverSettingsComponent {
           this.isLoading = false;
         },
         complete: () => {
-          this.selectedEmails.length = 0; // Clear selection
+          this.selectedEmails.length = 0;
         },
       });
   }

--- a/apps/frontend/src/app/management/components/settings/email-receiver-settings/email-receiver-settings.component.ts
+++ b/apps/frontend/src/app/management/components/settings/email-receiver-settings/email-receiver-settings.component.ts
@@ -1,0 +1,86 @@
+import { Component } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { EmailType } from 'apps/frontend/src/app/shared/types/email';
+import { BehaviorSubject, Observable, Subject, takeUntil } from 'rxjs';
+import { EmailReceiverService } from '../../../services/email/email-receiver.service';
+import { CustomEmailFilter } from './emailfilter';
+
+@Component({
+  selector: 'app-email-receiver-settings',
+  templateUrl: './email-receiver-settings.component.html',
+  styleUrl: './email-receiver-settings.component.css',
+})
+export class EmailReceiverSettingsComponent {
+  isLoading = false;
+  emailForm: FormGroup;
+  showEmailModal = false;
+
+  protected emailsSubject$ = new BehaviorSubject<EmailType[]>([]);
+  private readonly destroy$ = new Subject<void>();
+
+  protected emailFilter: CustomEmailFilter;
+  protected emailIdFilter: CustomEmailFilter;
+
+  constructor(
+    private fb: FormBuilder,
+    private emailService: EmailReceiverService
+  ) {
+    this.emailFilter = new CustomEmailFilter('mail');
+    this.emailIdFilter = new CustomEmailFilter('id');
+
+    this.emailForm = this.fb.group({
+      email: ['', [Validators.required, Validators.email]],
+    });
+  }
+
+  ngOnInit() {
+    this.loadEmailReceiver();
+  }
+
+  loadEmailReceiver(): void {
+    this.isLoading = true;
+    this.emailService
+      .getAllEmails()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (emails) => {
+          console.log(emails);
+          this.emailsSubject$.next(emails);
+          this.isLoading = false;
+        },
+
+        error: (error) => (this.isLoading = false),
+      });
+  }
+
+  addEmail() {
+    if (this.emailForm.valid) {
+      // hier muss ich die communication mit backend einbauen. wiederhole eingabe,
+      //wenn email bereits in Liste vorhanden, oder die eingabe keine korrekte email ist
+      this.isLoading = true;
+      const newEmail = {
+        email: this.emailForm.get('email')?.value,
+      };
+
+      const currentEmails = this.emailsSubject$.getValue();
+
+      //this.emailsSubject$.next([...currentEmails, newEmail]);
+      this.emailForm.reset();
+      this.showEmailModal = false;
+    }
+  }
+
+  removeEmail(emailToRemove: EmailType) {
+    this.emailService.deleteEmail(emailToRemove);
+    /*     this.emailsSubject$.next(
+      currentEmails.filter((email) => email.id !== emailToRemove.id)
+    ); */
+  }
+
+  saveChanges() {}
+
+  ngOnDestroy() {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+}

--- a/apps/frontend/src/app/management/components/settings/email-receiver-settings/emailfilter.ts
+++ b/apps/frontend/src/app/management/components/settings/email-receiver-settings/emailfilter.ts
@@ -1,0 +1,39 @@
+import { ClrDatagridFilterInterface } from '@clr/angular';
+import { EmailType } from 'apps/frontend/src/app/shared/types/email';
+import { Subject } from 'rxjs';
+
+export class CustomEmailFilter implements ClrDatagridFilterInterface<EmailType> {
+  public ranges: {
+    mail: string | null;
+    id: string | null;
+  } = {
+    mail: null,
+    id: null,
+  };
+
+  public changes = new Subject<any>();
+  public filterType: 'mail' | 'id';
+
+  constructor(filterType: 'mail' | 'id') {
+    this.filterType = filterType;
+  }
+
+  isActive(): boolean {
+    if (this.filterType === 'mail') {
+      return !!(this.ranges.mail || this.ranges.mail);
+    } else if (this.filterType === 'id') {
+      return !!(this.ranges.id || this.ranges.id);
+    } else {
+      return !!this.ranges.id;
+    }
+  }
+
+  accepts(backup: EmailType): boolean {
+    return true;
+  }
+
+  updateRanges(ranges: Partial<typeof this.ranges>): void {
+    Object.assign(this.ranges, ranges);
+    this.changes.next(true);
+  }
+}

--- a/apps/frontend/src/app/management/components/settings/notification-settings/notification-settings.component.ts
+++ b/apps/frontend/src/app/management/components/settings/notification-settings/notification-settings.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { FormArray, FormBuilder, FormGroup } from '@angular/forms';
 import { BehaviorSubject, forkJoin, Subject, takeUntil } from 'rxjs';
-import { NotificationService } from '../../../services/notification.service';
+import { NotificationService } from '../../../services/alert-notification/notification.service';
 import { AlertType } from '../../../../shared/types/alertType';
 import { AlertServiceService } from '../../../../alert/service/alert-service.service';
 

--- a/apps/frontend/src/app/management/services/alert-notification/notification.service.spec.ts
+++ b/apps/frontend/src/app/management/services/alert-notification/notification.service.spec.ts
@@ -2,8 +2,8 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { HttpClient } from '@angular/common/http';
 import { NotificationService } from './notification.service';
 import { of } from 'rxjs';
-import { AlertType } from '../../shared/types/alertType';
-import { SeverityType } from '../../shared/enums/severityType';
+import { AlertType } from '../../../shared/types/alertType';
+import { SeverityType } from '../../../shared/enums/severityType';
 
 describe('NotificationService', () => {
   let service: NotificationService;

--- a/apps/frontend/src/app/management/services/alert-notification/notification.service.ts
+++ b/apps/frontend/src/app/management/services/alert-notification/notification.service.ts
@@ -1,8 +1,8 @@
 import { Inject, Injectable } from '@angular/core';
-import { BASE_URL } from '../../shared/types/configuration';
+import { BASE_URL } from '../../../shared/types/configuration';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { AlertType } from '../../shared/types/alertType';
+import { AlertType } from '../../../shared/types/alertType';
 
 @Injectable({
   providedIn: 'root',

--- a/apps/frontend/src/app/management/services/email-receiver/email-receiver.service.spec.ts
+++ b/apps/frontend/src/app/management/services/email-receiver/email-receiver.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { EmailReceiverService } from './email-receiver.service';
+
+describe('EmailReceiverService', () => {
+  let service: EmailReceiverService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(EmailReceiverService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/apps/frontend/src/app/management/services/email-receiver/email-receiver.service.ts
+++ b/apps/frontend/src/app/management/services/email-receiver/email-receiver.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from '@angular/core';
 import { BASE_URL } from '../../../shared/types/configuration';
-import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { catchError, Observable, throwError } from 'rxjs';
 import { EmailType } from '../../../shared/types/email';
 
 @Injectable({
@@ -17,13 +17,32 @@ export class EmailReceiverService {
     return this.http.get<EmailType[]>(`${this.baseUrl}/mail`);
   }
 
-  updateEmailReceiver(email: EmailType): Observable<EmailType> {
-    return this.http.post<EmailType>(`${this.baseUrl}/mail`, {
-      mail: email.mail,
-    });
+  updateEmailReceiver(email: Partial<EmailType>): Observable<EmailType> {
+    return this.http
+      .post<EmailType>(`${this.baseUrl}/mail`, {
+        mail: email.mail,
+      })
+      .pipe(catchError(this.handleError));
   }
 
-  deleteEmail(email: EmailType): Observable<EmailType> {
-    return this.http.delete<EmailType>(`${this.baseUrl}/mail`);
+  deleteEmail(id: string): Observable<void> {
+    return this.http
+      .delete<void>(`${this.baseUrl}/mail/${id}`)
+      .pipe(catchError(this.handleError));
+  }
+
+  private handleError(error: HttpErrorResponse) {
+    let errorMessage = 'An error occurred';
+    if (error.error instanceof ErrorEvent) {
+      // Client-side error
+      errorMessage = error.error.message;
+    } else {
+      // Server-side error
+      errorMessage =
+        error.status === 409
+          ? 'Email already exists'
+          : `Error Code: ${error.status}\nMessage: ${error.message}`;
+    }
+    return throwError(() => error);
   }
 }

--- a/apps/frontend/src/app/management/services/email-receiver/email-receiver.service.ts
+++ b/apps/frontend/src/app/management/services/email-receiver/email-receiver.service.ts
@@ -1,0 +1,29 @@
+import { Inject, Injectable } from '@angular/core';
+import { BASE_URL } from '../../../shared/types/configuration';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { EmailType } from '../../../shared/types/email';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class EmailReceiverService {
+  constructor(
+    @Inject(BASE_URL) private readonly baseUrl: string,
+    private readonly http: HttpClient
+  ) {}
+
+  getAllEmailReceiver(): Observable<EmailType[]> {
+    return this.http.get<EmailType[]>(`${this.baseUrl}/mail`);
+  }
+
+  updateEmailReceiver(email: EmailType): Observable<EmailType> {
+    return this.http.post<EmailType>(`${this.baseUrl}/mail`, {
+      mail: email.mail,
+    });
+  }
+
+  deleteEmail(email: EmailType): Observable<EmailType> {
+    return this.http.delete<EmailType>(`${this.baseUrl}/mail`);
+  }
+}

--- a/apps/frontend/src/app/shared/components/confirm-dialog/component/confirm-dialog/confirm-dialog.component.html
+++ b/apps/frontend/src/app/shared/components/confirm-dialog/component/confirm-dialog/confirm-dialog.component.html
@@ -1,0 +1,1 @@
+<p>confirm-dialog works!</p>

--- a/apps/frontend/src/app/shared/components/confirm-dialog/component/confirm-dialog/confirm-dialog.component.html
+++ b/apps/frontend/src/app/shared/components/confirm-dialog/component/confirm-dialog/confirm-dialog.component.html
@@ -1,1 +1,14 @@
-<p>confirm-dialog works!</p>
+<clr-modal [(clrModalOpen)]="isOpen">
+  <h3 class="modal-title">{{ title }}</h3>
+  <div class="modal-body">
+    <p>{{ message }}</p>
+  </div>
+  <div class="modal-footer">
+    <button type="button" class="btn btn-outline" (click)="cancel()">
+      {{ cancelText }}
+    </button>
+    <button type="button" [class]="confirmButtonClass" (click)="confirm()">
+      {{ confirmText }}
+    </button>
+  </div>
+</clr-modal>

--- a/apps/frontend/src/app/shared/components/confirm-dialog/component/confirm-dialog/confirm-dialog.component.spec.ts
+++ b/apps/frontend/src/app/shared/components/confirm-dialog/component/confirm-dialog/confirm-dialog.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ConfirmDialogComponent } from './confirm-dialog.component';
+
+describe('ConfirmDialogComponent', () => {
+  let component: ConfirmDialogComponent;
+  let fixture: ComponentFixture<ConfirmDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ConfirmDialogComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ConfirmDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/apps/frontend/src/app/shared/components/confirm-dialog/component/confirm-dialog/confirm-dialog.component.spec.ts
+++ b/apps/frontend/src/app/shared/components/confirm-dialog/component/confirm-dialog/confirm-dialog.component.spec.ts
@@ -1,23 +1,63 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ConfirmDialogComponent } from './confirm-dialog.component';
 
 describe('ConfirmDialogComponent', () => {
   let component: ConfirmDialogComponent;
-  let fixture: ComponentFixture<ConfirmDialogComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [ConfirmDialogComponent]
-    })
-    .compileComponents();
-
-    fixture = TestBed.createComponent(ConfirmDialogComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+  beforeEach(() => {
+    component = new ConfirmDialogComponent();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should initialize with default values', () => {
+    expect(component.isOpen).toBe(false);
+    expect(component.title).toBe('Confirm Action');
+    expect(component.message).toBe('Are you sure you want to proceed?');
+    expect(component.confirmText).toBe('Confirm');
+    expect(component.cancelText).toBe('Cancel');
+    expect(component.confirmButtonClass).toBe('btn btn-primary');
+  });
+
+  it('should call onConfirm and close dialog when confirm is called', () => {
+    const mockOnConfirm = vi.fn();
+    component.isOpen = true;
+    component.onConfirm = mockOnConfirm;
+
+    component.confirm();
+
+    expect(mockOnConfirm).toHaveBeenCalled();
+    expect(component.isOpen).toBe(false);
+  });
+
+  it('should call onCancel and close dialog when cancel is called', () => {
+    const mockOnCancel = vi.fn();
+    component.isOpen = true;
+    component.onCancel = mockOnCancel;
+
+    component.cancel();
+
+    expect(mockOnCancel).toHaveBeenCalled();
+    expect(component.isOpen).toBe(false);
+  });
+
+  it('should accept custom button class', () => {
+    const customClass = 'btn btn-danger';
+    component.confirmButtonClass = customClass;
+
+    expect(component.confirmButtonClass).toBe(customClass);
+  });
+
+  it('should accept custom title and message', () => {
+    const customTitle = 'Delete Item';
+    const customMessage = 'Do you want to delete this item?';
+
+    component.title = customTitle;
+    component.message = customMessage;
+
+    expect(component.title).toBe(customTitle);
+    expect(component.message).toBe(customMessage);
   });
 });

--- a/apps/frontend/src/app/shared/components/confirm-dialog/component/confirm-dialog/confirm-dialog.component.ts
+++ b/apps/frontend/src/app/shared/components/confirm-dialog/component/confirm-dialog/confirm-dialog.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-confirm-dialog',
+  templateUrl: './confirm-dialog.component.html',
+  styleUrl: './confirm-dialog.component.css'
+})
+export class ConfirmDialogComponent {
+
+}

--- a/apps/frontend/src/app/shared/components/confirm-dialog/component/confirm-dialog/confirm-dialog.component.ts
+++ b/apps/frontend/src/app/shared/components/confirm-dialog/component/confirm-dialog/confirm-dialog.component.ts
@@ -1,10 +1,27 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 
 @Component({
   selector: 'app-confirm-dialog',
   templateUrl: './confirm-dialog.component.html',
-  styleUrl: './confirm-dialog.component.css'
+  styleUrl: './confirm-dialog.component.css',
 })
 export class ConfirmDialogComponent {
+  @Input() isOpen = false;
+  @Input() title = 'Confirm Action';
+  @Input() message = 'Are you sure you want to proceed?';
+  @Input() confirmText = 'Confirm';
+  @Input() cancelText = 'Cancel';
+  @Input() confirmButtonClass = 'btn btn-primary';
+  @Input() onConfirm: () => void = () => {};
+  @Input() onCancel: () => void = () => {};
 
+  confirm() {
+    this.onConfirm();
+    this.isOpen = false;
+  }
+
+  cancel() {
+    this.onCancel();
+    this.isOpen = false;
+  }
 }

--- a/apps/frontend/src/app/shared/components/confirm-dialog/service/confirm-dialog.service.spec.ts
+++ b/apps/frontend/src/app/shared/components/confirm-dialog/service/confirm-dialog.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ConfirmDialogService } from './confirm-dialog.service';
+
+describe('ConfirmDialogService', () => {
+  let service: ConfirmDialogService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ConfirmDialogService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/apps/frontend/src/app/shared/components/confirm-dialog/service/confirm-dialog.service.spec.ts
+++ b/apps/frontend/src/app/shared/components/confirm-dialog/service/confirm-dialog.service.spec.ts
@@ -1,16 +1,160 @@
-import { TestBed } from '@angular/core/testing';
-
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ConfirmDialogService } from './confirm-dialog.service';
+import { ConfirmDialogComponent } from '../component/confirm-dialog/confirm-dialog.component';
+import {
+  ApplicationRef,
+  ComponentFactoryResolver,
+  ComponentRef,
+  Injector,
+} from '@angular/core';
 
 describe('ConfirmDialogService', () => {
   let service: ConfirmDialogService;
+  let componentFactoryResolver: ComponentFactoryResolver;
+  let appRef: ApplicationRef;
+  let injector: Injector;
+  let mockComponentRef: Partial<ComponentRef<ConfirmDialogComponent>>;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
-    service = TestBed.inject(ConfirmDialogService);
+    mockComponentRef = {
+      instance: {
+        isOpen: false,
+        title: '',
+        message: '',
+        confirmText: '',
+        cancelText: '',
+        confirmButtonClass: '',
+        onConfirm: function (): void {
+          throw new Error('Function not implemented.');
+        },
+        onCancel: function (): void {
+          throw new Error('Function not implemented.');
+        },
+        confirm: function (): void {
+          throw new Error('Function not implemented.');
+        },
+        cancel: function (): void {
+          throw new Error('Function not implemented.');
+        },
+      },
+      hostView: {
+        detectChanges: vi.fn(),
+        markForCheck: vi.fn(),
+        detach: vi.fn(),
+        destroy: vi.fn(),
+        destroyed: false,
+        onDestroy: function (callback: Function): void {
+          throw new Error('Function not implemented.');
+        },
+        checkNoChanges: function (): void {
+          throw new Error('Function not implemented.');
+        },
+        reattach: function (): void {
+          throw new Error('Function not implemented.');
+        },
+      },
+      destroy: vi.fn(),
+    };
+
+    componentFactoryResolver = {
+      resolveComponentFactory: vi.fn().mockReturnValue({
+        create: vi.fn().mockReturnValue(mockComponentRef),
+      }),
+    } as any;
+
+    appRef = {
+      attachView: vi.fn(),
+      detachView: vi.fn(),
+    } as any;
+
+    injector = {} as Injector;
+
+    service = new ConfirmDialogService(
+      componentFactoryResolver,
+      appRef,
+      injector
+    );
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
   });
 
-  it('should be created', () => {
+  it('should create the service', () => {
     expect(service).toBeTruthy();
+  });
+
+  describe('confirm', () => {
+    it('should create and show confirmation dialog', async () => {
+      const confirmPromise = service.confirm({ title: 'Test Title' });
+
+      expect(
+        componentFactoryResolver.resolveComponentFactory
+      ).toHaveBeenCalledWith(ConfirmDialogComponent);
+      expect(appRef.attachView).toHaveBeenCalled();
+      expect(mockComponentRef.instance).toHaveProperty('isOpen', true);
+      expect(mockComponentRef.instance).toHaveProperty('title', 'Test Title');
+
+      // Simulate confirmation
+      (mockComponentRef.instance as any).onConfirm();
+      const result = await confirmPromise;
+      expect(result).toBe(true);
+    });
+
+    it('should handle cancellation', async () => {
+      const confirmPromise = service.confirm();
+
+      // Simulate cancellation
+      (mockComponentRef.instance as any).onCancel();
+      const result = await confirmPromise;
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('handleConfirmation', () => {
+    it('should execute onConfirm callback when confirmed', async () => {
+      const onConfirm = vi.fn();
+      const onCancel = vi.fn();
+      const options = { title: 'Test' };
+
+      const confirmSpy = vi.spyOn(service, 'confirm').mockResolvedValue(true);
+
+      await service.handleConfirmation(options, onConfirm, onCancel);
+
+      expect(confirmSpy).toHaveBeenCalledWith(options);
+      expect(onConfirm).toHaveBeenCalled();
+      expect(onCancel).not.toHaveBeenCalled();
+    });
+
+    it('should execute onCancel callback when cancelled', async () => {
+      const onConfirm = vi.fn();
+      const onCancel = vi.fn();
+      const options = { title: 'Test' };
+
+      const confirmSpy = vi.spyOn(service, 'confirm').mockResolvedValue(false);
+
+      await service.handleConfirmation(options, onConfirm, onCancel);
+
+      expect(confirmSpy).toHaveBeenCalledWith(options);
+      expect(onConfirm).not.toHaveBeenCalled();
+      expect(onCancel).toHaveBeenCalled();
+    });
+
+    it('should handle errors gracefully', async () => {
+      const onConfirm = vi.fn();
+      const error = new Error('Test error');
+      const consoleSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      vi.spyOn(service, 'confirm').mockRejectedValue(error);
+
+      await service.handleConfirmation({}, onConfirm);
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Error in confirmation flow:',
+        error
+      );
+      expect(onConfirm).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/frontend/src/app/shared/components/confirm-dialog/service/confirm-dialog.service.ts
+++ b/apps/frontend/src/app/shared/components/confirm-dialog/service/confirm-dialog.service.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ConfirmDialogService {
+
+  constructor() { }
+}

--- a/apps/frontend/src/app/shared/components/confirm-dialog/service/confirm-dialog.service.ts
+++ b/apps/frontend/src/app/shared/components/confirm-dialog/service/confirm-dialog.service.ts
@@ -1,9 +1,82 @@
-import { Injectable } from '@angular/core';
+import {
+  ApplicationRef,
+  ComponentFactoryResolver,
+  ComponentRef,
+  EmbeddedViewRef,
+  Injectable,
+  Injector,
+  Type,
+} from '@angular/core';
+import { ConfirmDialogComponent } from '../component/confirm-dialog/confirm-dialog.component';
+import { ConfirmationOptions } from '../../../types/confirmationOptions';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class ConfirmDialogService {
+  private modalComponentRef: ComponentRef<ConfirmDialogComponent> | null = null;
 
-  constructor() { }
+  constructor(
+    private componentFactoryResolver: ComponentFactoryResolver,
+    private appRef: ApplicationRef,
+    private injector: Injector
+  ) {}
+
+  confirm(options: ConfirmationOptions = {}): Promise<boolean> {
+    return new Promise((resolve) => {
+      this.modalComponentRef = this.createComponent(ConfirmDialogComponent);
+      Object.assign(this.modalComponentRef.instance, {
+        isOpen: true,
+        ...options,
+        onConfirm: () => {
+          resolve(true);
+          this.removeComponent();
+        },
+        onCancel: () => {
+          resolve(false);
+          this.removeComponent();
+        },
+      });
+    });
+  }
+
+  private createComponent<T>(component: Type<T>): ComponentRef<T> {
+    const componentRef = this.componentFactoryResolver
+      .resolveComponentFactory(component)
+      .create(this.injector);
+
+    this.appRef.attachView(componentRef.hostView);
+
+    const domElem = (componentRef.hostView as EmbeddedViewRef<any>)
+      .rootNodes[0];
+    document.body.appendChild(domElem);
+
+    return componentRef;
+  }
+
+  private removeComponent(): void {
+    if (this.modalComponentRef) {
+      this.appRef.detachView(this.modalComponentRef.hostView);
+      this.modalComponentRef.destroy();
+      this.modalComponentRef = null;
+    }
+  }
+
+  async handleConfirmation(
+    options: ConfirmationOptions,
+    onConfirm: () => void,
+    onCancel?: () => void
+  ): Promise<void> {
+    try {
+      const result = await this.confirm(options);
+
+      if (result) {
+        await onConfirm();
+      } else if (onCancel) {
+        await onCancel();
+      }
+    } catch (error) {
+      console.error('Error in confirmation flow:', error);
+    }
+  }
 }

--- a/apps/frontend/src/app/shared/types/confirmationOptions.ts
+++ b/apps/frontend/src/app/shared/types/confirmationOptions.ts
@@ -1,0 +1,7 @@
+export interface ConfirmationOptions {
+  title?: string;
+  message?: string;
+  confirmText?: string;
+  cancelText?: string;
+  confirmButtonClass?: string;
+}

--- a/apps/frontend/src/app/shared/types/email.ts
+++ b/apps/frontend/src/app/shared/types/email.ts
@@ -1,0 +1,4 @@
+export interface EmailType {
+  id: string;
+  mail: string;
+}


### PR DESCRIPTION
from now on we can manage email lists.
emails are listed in a datagrid.
Adding and deleting runs via the backend.
I have also implemented a generic confirmation component. we can use this anywhere in frontend if we need a confirmation for an action!