### PR TITLE
add all remaining requested data from issue

### DIFF
--- a/apps/backend/src/app/alerting/alerting.service.ts
+++ b/apps/backend/src/app/alerting/alerting.service.ts
@@ -137,11 +137,12 @@ export class AlertingService extends PaginationService implements OnModuleInit {
         // get History of task associated alerts
         const repeatedAlerts = await repository
           .createQueryBuilder('alert')
-          .select('alertType.severity, alertType.name AS type, backup.taskId, COUNT(alert.id) as count')
+          .select('alertType.severity, alertType.name AS type, backup.taskId, task.displayName, COUNT(alert.id) as count')
           .leftJoin('alert.backup', 'backup')
+          .leftJoin('backup.taskId', 'task')
           .leftJoin('alert.alertType', 'alertType')
           .where('backup.taskId IS NOT NULL')
-          .groupBy('backup.taskId, alertType.severity, alertType.name')
+          .groupBy('backup.taskId, alertType.severity, alertType.name, task.displayName')
           .having('COUNT(alert.id) > 1')
           .getRawMany() as RepeatedAlertDto[];
 
@@ -163,8 +164,11 @@ export class AlertingService extends PaginationService implements OnModuleInit {
                 alertId: alertEntity.id,
               });
             }
+            repeatedAlert.latestAlert = alertEntities[0];
           }
-          repeatedAlert.history = history;
+          
+          repeatedAlert.history = history.slice(0,5);
+          repeatedAlert.firstOccurence = history[history.length - 1].date;
         }
         retAlerts.push(...repeatedAlerts);
       }
@@ -211,7 +215,8 @@ export class AlertingService extends PaginationService implements OnModuleInit {
         for (const alertEntity of alertEntities) {
           history.push({  date: alertEntity.creationDate, alertId: alertEntity.id });
         }
-        repeatedStorageAlert.history = history;
+        repeatedStorageAlert.history = history.slice(0,5);
+        repeatedStorageAlert.firstOccurence = history[history.length - 1].date;
       }
       retAlerts.push(...repeatedStorageAlerts);
     }

--- a/apps/backend/src/app/alerting/dto/alertSummary.ts
+++ b/apps/backend/src/app/alerting/dto/alertSummary.ts
@@ -60,6 +60,11 @@ export class RepeatedAlertDto {
   latestAlert?: Alert;
 
   @ApiProperty({ 
+    description: 'First Alert occurence', 
+  })
+  firstOccurence?: Date;
+
+  @ApiProperty({ 
     description: 'Alert History', 
   })
   history?: AlertOcurrenceDto[];
@@ -68,6 +73,11 @@ export class RepeatedAlertDto {
     description: 'Task ID of alert', 
   })
   taskId?: string;
+
+  @ApiProperty({ 
+    description: 'Task Name of alert', 
+  })
+  taskDisplayName?: string;
 
   @ApiProperty({ 
     description: 'Storage ID of alert', 


### PR DESCRIPTION
Adds some additional info to the retrieved data for the "multiple same alerts" feature

```diff
"repeatedAlerts": [
    {
      "severity": "WARNING",
      "type": "SIZE_ALERT",
      "taskId": "ae24d165-b378-4d31-88fb-be0e997ddb35",
+    "taskdisplayname": "qa-sles12fix-hana_arm_val", // NEW for more useful task display
      "count": "1179",
+     "latestAlert": { // NEW: contains whole latest alert from series of reoccuring events
#         ...
#     },
        "alertType": {
          "id": "384bb3e8-42ad-401a-992b-2d9e0157924b",
          "name": "SIZE_ALERT",
          "severity": "WARNING",
          "user_active": true,
          "master_active": true
        }
      },
      "history": [
         ...
       ],
+    "firstOccurence": "2025-01-13T18:13:11.708Z" // NEW

```