### PR TITLE
Change Data Stores column types to float

### DIFF
--- a/apps/backend/src/app/dataStores/entity/dataStore.entity.ts
+++ b/apps/backend/src/app/dataStores/entity/dataStore.entity.ts
@@ -21,21 +21,21 @@ export class DataStoreEntity {
     description: 'Capacity in GB',
     required: true,
   })
-  @Column({ nullable: false })
+  @Column({ type: 'float', nullable: false })
   capacity!: number;
 
   @ApiProperty({
     description: 'High water mark in GB',
     required: true,
   })
-  @Column({ nullable: false })
+  @Column({ type: 'float', nullable: false })
   highWaterMark!: number;
 
   @ApiProperty({
     description: 'Filled in GB',
     required: true,
   })
-  @Column({ nullable: false })
+  @Column({ type: 'float', nullable: false })
   filled!: number;
 
   @ApiProperty({

--- a/apps/backend/src/app/db-config.service.ts
+++ b/apps/backend/src/app/db-config.service.ts
@@ -37,6 +37,7 @@ import { AddAlertAdditionalBackup1736630779875 } from './migrations/173663077987
 import { StorageOverflowTime1736550460789 } from './migrations/1736550460789-StorageOverflowTime';
 import { DeprecatedFlag1737107214086 } from './migrations/1737107214086-DeprecatedFlag';
 import { DeprecatedFlagNewAlerts1737406388351 } from './migrations/1737406388351-DeprecatedFlagNewAlerts';
+import { ChangeDatastoresColumnTypesToFloat1738509170401 } from './migrations/1738509170401-changeDatastoresColumnTypesToFloat';
 
 /**
  * Used by NestJS to reach database.
@@ -95,6 +96,7 @@ export class DbConfigService implements TypeOrmOptionsFactory {
         StorageOverflowTime1736550460789,
         DeprecatedFlag1737107214086,
         DeprecatedFlagNewAlerts1737406388351,
+        ChangeDatastoresColumnTypesToFloat1738509170401,
       ],
       logging: true,
       logger: 'debug',

--- a/apps/backend/src/app/migrations/1738509170401-changeDatastoresColumnTypesToFloat.ts
+++ b/apps/backend/src/app/migrations/1738509170401-changeDatastoresColumnTypesToFloat.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ChangeDatastoresColumnTypesToFloat1738509170401 implements MigrationInterface {
+    name = 'ChangeDatastoresColumnTypesToFloat1738509170401'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "DataStore" DROP COLUMN "capacity"`);
+        await queryRunner.query(`ALTER TABLE "DataStore" ADD "capacity" double precision NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "DataStore" DROP COLUMN "highWaterMark"`);
+        await queryRunner.query(`ALTER TABLE "DataStore" ADD "highWaterMark" double precision NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "DataStore" DROP COLUMN "filled"`);
+        await queryRunner.query(`ALTER TABLE "DataStore" ADD "filled" double precision NOT NULL`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "DataStore" DROP COLUMN "filled"`);
+        await queryRunner.query(`ALTER TABLE "DataStore" ADD "filled" integer NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "DataStore" DROP COLUMN "highWaterMark"`);
+        await queryRunner.query(`ALTER TABLE "DataStore" ADD "highWaterMark" integer NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "DataStore" DROP COLUMN "capacity"`);
+        await queryRunner.query(`ALTER TABLE "DataStore" ADD "capacity" integer NOT NULL`);
+    }
+
+}


### PR DESCRIPTION
Although I specified type: 'float', double precision was used in the generated migration. This is because TypeORM chooses the most suitable type for float depending on the database engine used and thus automatically . If we explicitly want to have float in the database, a new migration must be created with type: 'real'